### PR TITLE
Add Python CLI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python cache files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Python build artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test and coverage artifacts
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Type checking
+.mypy_cache/
+.ruff_cache/
+
+# OS/editor files
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "owasp-agent-security-regression-harness"
+version = "0.0.1"
+description = "OWASP harness for executable security regression testing of agentic applications and MCP-integrated systems."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "Mert Satilmaz", email = "mert.satilmaz@owasp.org" }
+]
+keywords = [
+  "owasp",
+  "agent-security",
+  "ai-security",
+  "llm-security",
+  "mcp",
+  "security-testing",
+  "regression-testing"
+]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Information Technology",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Security",
+  "Topic :: Software Development :: Testing"
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/OWASP/Agent-Security-Regression-Harness"
+Repository = "https://github.com/OWASP/Agent-Security-Regression-Harness"
+Issues = "https://github.com/OWASP/Agent-Security-Regression-Harness/issues"
+
+[project.scripts]
+agent-harness = "agent_harness.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/agent_harness/__init__.py
+++ b/src/agent_harness/__init__.py
@@ -1,0 +1,3 @@
+"""OWASP Agent Security Regression Harness."""
+
+__version__ = "0.0.1"

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -1,0 +1,56 @@
+"""Command line interface for the OWASP Agent Security Regression Harness."""
+
+from __future__ import annotations
+
+import argparse
+
+
+VERSION = "0.0.1"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agent-harness",
+        description=(
+            "Run executable security regression scenarios against "
+            "agentic applications and MCP-integrated systems."
+        ),
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser(
+        "version",
+        help="Print the harness version.",
+    )
+
+    subparsers.add_parser(
+        "validate",
+        help="Validate a scenario file. Not implemented yet.",
+    )
+
+    subparsers.add_parser(
+        "run",
+        help="Run a scenario file. Not implemented yet.",
+    )
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "version":
+        print(f"agent-harness {VERSION}")
+        return 0
+
+    if args.command in {"validate", "run"}:
+        parser.error(f"'{args.command}' is not implemented yet")
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+"""Tests for the agent-harness CLI."""
+
+from __future__ import annotations
+
+import sys
+
+from agent_harness.cli import VERSION, main
+
+
+def test_version_command_prints_version(capsys, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["agent-harness", "version"])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out.strip() == f"agent-harness {VERSION}"


### PR DESCRIPTION
## Summary

Adds the initial Python package skeleton and CLI entry point.

This includes:

- `pyproject.toml`
- `agent-harness` console command
- `version`, `validate`, and `run` subcommands
- `.gitignore`
- Basic CLI test

## Validation

```bash
agent-harness --help
agent-harness version
python -m pytest