### PR TITLE
Add dry-run result output

### DIFF
--- a/schemas/result.schema.json
+++ b/schemas/result.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://owasp.org/schemas/agent-security-regression-harness/result.schema.json",
+  "title": "OWASP Agent Security Regression Harness Result",
+  "type": "object",
+  "required": [
+    "scenario_id",
+    "mode",
+    "result",
+    "assertions",
+    "trace"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "scenario_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "dry_run",
+        "live"
+      ]
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "error",
+        "not_run"
+      ]
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "result"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "fail",
+              "error",
+              "not_run"
+            ]
+          },
+          "evidence": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "required": [
+        "messages",
+        "tool_calls",
+        "events"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "tool_calls": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
+from agent_harness.runner import dry_run_scenario
 from agent_harness.scenario import ScenarioValidationError, load_scenario
 
 
@@ -38,11 +40,20 @@ def build_parser() -> argparse.ArgumentParser:
 
     run_parser = subparsers.add_parser(
         "run",
-        help="Run a scenario file. Not implemented yet.",
+        help="Run a scenario file.",
     )
     run_parser.add_argument(
         "scenario_file",
         help="Path to the scenario YAML file.",
+    )
+    run_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate the scenario and emit result JSON without executing a target.",
+    )
+    run_parser.add_argument(
+        "--out",
+        help="Optional path to write result JSON.",
     )
 
     return parser
@@ -67,7 +78,24 @@ def main() -> int:
         return 0
 
     if args.command == "run":
-        parser.error("'run' is not implemented yet")
+        if not args.dry_run:
+            parser.error("'run' currently requires --dry-run")
+
+        try:
+            scenario = load_scenario(args.scenario_file)
+        except ScenarioValidationError as exc:
+            print(f"invalid: {exc}", file=sys.stderr)
+            return 1
+
+        result = dry_run_scenario(scenario)
+        result_json = result.to_json()
+
+        if args.out:
+            Path(args.out).write_text(result_json + "\n", encoding="utf-8")
+        else:
+            print(result_json)
+
+        return 0
 
     parser.print_help()
     return 0

--- a/src/agent_harness/result.py
+++ b/src/agent_harness/result.py
@@ -1,0 +1,59 @@
+"""Result models for harness execution."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from agent_harness.trace import Trace
+
+
+ResultStatus = Literal["pass", "fail", "error", "not_run"]
+RunMode = Literal["dry_run", "live"]
+
+
+@dataclass(frozen=True)
+class AssertionResult:
+    """Result of one assertion evaluation."""
+
+    id: str
+    result: ResultStatus
+    evidence: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the assertion result to a JSON-serializable dictionary."""
+        data: dict[str, Any] = {
+            "id": self.id,
+            "result": self.result,
+        }
+
+        if self.evidence is not None:
+            data["evidence"] = self.evidence
+
+        return data
+
+
+@dataclass(frozen=True)
+class HarnessResult:
+    """Top-level result produced by a harness run."""
+
+    scenario_id: str
+    mode: RunMode
+    result: ResultStatus
+    assertions: list[AssertionResult] = field(default_factory=list)
+    trace: Trace = field(default_factory=Trace)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the harness result to a JSON-serializable dictionary."""
+        return {
+            "scenario_id": self.scenario_id,
+            "mode": self.mode,
+            "result": self.result,
+            "assertions": [assertion.to_dict() for assertion in self.assertions],
+            "trace": self.trace.to_dict(),
+        }
+
+    def to_json(self) -> str:
+        """Convert the harness result to formatted JSON."""
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)

--- a/src/agent_harness/runner.py
+++ b/src/agent_harness/runner.py
@@ -1,0 +1,32 @@
+"""Scenario runner."""
+
+from __future__ import annotations
+
+from agent_harness.result import AssertionResult, HarnessResult
+from agent_harness.scenario import Scenario
+from agent_harness.trace import Trace
+
+
+def dry_run_scenario(scenario: Scenario) -> HarnessResult:
+    """Create a dry-run result for a validated scenario.
+
+    Dry-run mode validates the scenario and emits the result shape without
+    executing a target agent. Assertions are marked as not_run because no
+    system behavior has been observed.
+    """
+    assertion_results = [
+        AssertionResult(
+            id=assertion["type"],
+            result="not_run",
+            evidence="dry-run mode does not execute assertions",
+        )
+        for assertion in scenario.raw["assertions"]
+    ]
+
+    return HarnessResult(
+        scenario_id=scenario.id,
+        mode="dry_run",
+        result="not_run",
+        assertions=assertion_results,
+        trace=Trace(),
+    )

--- a/src/agent_harness/trace.py
+++ b/src/agent_harness/trace.py
@@ -1,0 +1,23 @@
+"""Execution trace models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Trace:
+    """Execution trace captured during a scenario run."""
+
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the trace to a JSON-serializable dictionary."""
+        return {
+            "messages": self.messages,
+            "tool_calls": self.tool_calls,
+            "events": self.events,
+        }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 
 from agent_harness.cli import VERSION, main
@@ -67,3 +68,61 @@ def test_validate_command_rejects_missing_fields(capsys, monkeypatch, tmp_path):
 
     assert exit_code == 1
     assert "missing required fields" in captured.err
+
+
+def test_run_dry_run_outputs_result_json(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent-harness", "run", str(scenario_file), "--dry-run"],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert result["scenario_id"] == "goal_hijack.basic_001"
+    assert result["mode"] == "dry_run"
+    assert result["result"] == "not_run"
+    assert result["assertions"][0]["id"] == "no_denied_tool_call"
+    assert result["assertions"][0]["result"] == "not_run"
+    assert result["trace"] == {
+        "messages": [],
+        "tool_calls": [],
+        "events": [],
+    }
+
+
+def test_run_dry_run_writes_result_file(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    output_file = tmp_path / "result.json"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--dry-run",
+            "--out",
+            str(output_file),
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    result = json.loads(output_file.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert captured.out == ""
+    assert result["scenario_id"] == "goal_hijack.basic_001"
+    assert result["mode"] == "dry_run"
+    assert result["result"] == "not_run"


### PR DESCRIPTION
## Summary

Adds the first `agent-harness run` behavior through dry-run result output.

This includes:

- Result model
- Trace model
- Dry-run runner
- Result JSON schema
- `agent-harness run --dry-run`
- `--out` support for writing result JSON
- CLI tests for dry-run output and file writing

## Validation

```bash
agent-harness run scenarios/goal_hijack/basic.yaml --dry-run
agent-harness run scenarios/goal_hijack/basic.yaml --dry-run --out result.json
python -m pytest