### PR TITLE
Mark package as typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,9 @@ agent-harness = "agent_harness.cli:main"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+agent_harness = ["py.typed"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+


### PR DESCRIPTION
## Summary

Adds the `py.typed` marker and package data configuration so type checkers recognize `agent_harness` as a typed package.

## Validation

```bash
python -m pip install -e .
python -m pytest