### PR TITLE
Add HTTP live adapter

### DIFF
--- a/examples/targets/http_agent.py
+++ b/examples/targets/http_agent.py
@@ -1,0 +1,61 @@
+"""Example HTTP target for live harness testing."""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+
+HOST = "127.0.0.1"
+PORT = 8000
+
+
+class AgentRequestHandler(BaseHTTPRequestHandler):
+    """Handle HTTP requests for the example agent target."""
+
+    def do_POST(self) -> None:
+        """Handle POST /run requests."""
+        if self.path != "/run":
+            self.send_error(404, "not found")
+            return
+
+        content_length = int(self.headers.get("Content-Length", "0"))
+        request_body = self.rfile.read(content_length)
+        payload = json.loads(request_body.decode("utf-8"))
+        scenario_input = payload.get("input", {})
+        user_message = scenario_input.get("user_message", "")
+
+        trace: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": user_message,
+                },
+                {
+                    "role": "assistant",
+                    "content": "Here is the summary.",
+                },
+            ],
+            "tool_calls": [],
+            "events": [],
+        }
+
+        response_body = json.dumps(trace).encode("utf-8")
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response_body)))
+        self.end_headers()
+        self.wfile.write(response_body)
+
+def main() -> None:
+    """Run the example HTTP target server."""
+    server = HTTPServer((HOST, PORT), AgentRequestHandler)
+    print(f"Example HTTP target listening on http://{HOST}:{PORT}/run")
+    server.serve_forever()
+
+if __name__ == "__main__":
+    main()
+
+

--- a/src/agent_harness/adapters.py
+++ b/src/agent_harness/adapters.py
@@ -1,0 +1,52 @@
+"""Target adapters for live scenario execution."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib import error, request
+
+from agent_harness.scenario import Scenario
+from agent_harness.trace import Trace, TraceValidationError
+
+class AdapterError(RuntimeError):
+    """Raised when a live target adapter fails"""
+    
+def build_http_request_body(scenario: Scenario) -> dict[str, Any]:
+    """Build the JSON request body sent to an HTTP target."""
+    return {
+        "scenario_id": scenario.id,
+        "input": scenario.raw["input"],
+    }
+
+def run_http_target(scenario: Scenario, target_url: str) -> Trace:
+    """Run a scenario against an HTTP target and return its trace."""
+    body = build_http_request_body(scenario)
+    request_data = json.dumps(body).encode("utf-8")
+    http_request = request.Request(
+        target_url,
+        data=request_data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    
+    try:
+        with request.urlopen(http_request, timeout=30) as response:
+            response_text = response.read().decode("utf-8")
+    except error.URLError as exc:
+        raise AdapterError(f"HTTP target request failed: {exc}") from exc
+    
+    try:
+        trace_data = json.loads(response_text)
+    except json.JSONDecodeError as exc:
+        raise AdapterError(f"HTTP target returned invalid JSON: {exc}") from exc
+    
+    try:
+        return Trace.from_dict(trace_data)
+    except TraceValidationError as exc:
+        raise AdapterError(f"HTTP target returned invalid trace: {exc}") from exc 
+    
+

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -6,7 +6,12 @@ import argparse
 import sys
 from pathlib import Path
 
-from agent_harness.runner import dry_run_scenario, run_scenario_with_trace
+from agent_harness.adapters import AdapterError
+from agent_harness.runner import (
+    dry_run_scenario, 
+    run_scenario_live, 
+    run_scenario_with_trace
+)
 from agent_harness.scenario import ScenarioValidationError, load_scenario
 from agent_harness.trace import TraceValidationError, load_trace
 
@@ -60,6 +65,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--trace-file",
         help="Evaluate assertions against an existing trace JSON file.",
     )
+    run_parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Run the scenario against a live target.",
+    )
+    run_parser.add_argument(
+        "--target-url",
+        help="HTTP URL for the live target.",
+    )
 
     return parser
 
@@ -83,11 +97,21 @@ def main() -> int:
         return 0
 
     if args.command == "run":
-        if args.dry_run and args.trace_file:
-            parser.error("'run' accepts either --dry-run or --trace-file, not both")
+        selected_modes = [
+            args.dry_run,
+            args.trace_file is not None,
+            args.live,
+        ]
+
+        if sum(bool(mode) for mode in selected_modes) != 1:
+            parser.error("'run' requires exactly one of --dry-run, --trace-file, or --live"
+            )
+
+        if args.live and not args.target_url:
+            parser.error("'run --live' requires --target-url")
         
-        if not args.dry_run and not args.trace_file:
-            parser.error("'run' currently requires --dry-run or --trace-file")
+        if args.target_url and not args.live:
+            parser.error("--target-url can only be used with --live")
 
         try:
             scenario = load_scenario(args.scenario_file)
@@ -97,6 +121,14 @@ def main() -> int:
 
         if args.dry_run:
             result = dry_run_scenario(scenario)
+        elif args.live:
+            try:
+                assert args.target_url is not None
+                result = run_scenario_live(scenario, args.target_url)
+            except AdapterError as exc:
+                print(f"adapter error: {exc}", file=sys.stderr)
+                return 1
+
         else:
             try:
                 trace = load_trace(args.trace_file)

--- a/src/agent_harness/runner.py
+++ b/src/agent_harness/runner.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from agent_harness.adapters import run_http_target
+from agent_harness.assertions import evaluate_assertions
 from agent_harness.result import AssertionResult, HarnessResult, aggregate_assertion_results
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace
-from agent_harness.assertions import evaluate_assertions
 
 
 def dry_run_scenario(scenario: Scenario) -> HarnessResult:
@@ -32,6 +33,7 @@ def dry_run_scenario(scenario: Scenario) -> HarnessResult:
         trace=Trace(),
     )
 
+
 def run_scenario_with_trace(scenario: Scenario, trace: Trace) -> HarnessResult:
     """Evaluate a scenario against an existing execution trace."""
     assertion_results = evaluate_assertions(scenario, trace)
@@ -44,3 +46,19 @@ def run_scenario_with_trace(scenario: Scenario, trace: Trace) -> HarnessResult:
         assertions=assertion_results,
         trace=trace,
     )
+
+
+def run_scenario_live(scenario: Scenario, target_url: str) -> HarnessResult:
+    """Run a scenario against a live HTTP target."""
+    trace = run_http_target(scenario, target_url)
+    assertion_results = evaluate_assertions(scenario, trace)
+    top_level_result = aggregate_assertion_results(assertion_results)
+
+    return HarnessResult(
+        scenario_id=scenario.id,
+        mode="live",
+        result=top_level_result,
+        assertions=assertion_results,
+        trace=trace,
+    )
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,3 +228,31 @@ def test_run_trace_file_passes_denied_tool_call_when_no_denied_tool_is_observed(
     assert result["assertions"][0]["id"] == "no_denied_tool_call"
     assert result["assertions"][0]["result"] == "pass"
     assert result["assertions"][0]["evidence"] == "no denied tool calls observed"
+
+
+def test_run_live_returns_adapter_error_when_target_is_unreachable(
+    capsys, monkeypatch, tmp_path
+):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--live",
+            "--target-url",
+            "http://127.0.0.1:1/run",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "adapter error:" in captured.err


### PR DESCRIPTION
## Summary

Adds initial live execution support through a generic HTTP JSON adapter.

This includes:

- `run_http_target()` adapter for POSTing scenario input to a live target
- Live runner path using returned trace JSON
- `agent-harness run --live --target-url ...`
- Clean adapter error handling in the CLI
- Example HTTP target server under `examples/targets/http_agent.py`
- CLI test for unreachable live target handling

## Validation

```bash
python examples/targets/http_agent.py
agent-harness run scenarios/goal_hijack/basic.yaml --live --target-url http://127.0.0.1:8000/run
agent-harness run scenarios/goal_hijack/basic.yaml --live --target-url http://127.0.0.1:1/run
python -m pytest