### PR TITLE
Add trace recorder helper

### DIFF
--- a/src/agent_harness/recorder.py
+++ b/src/agent_harness/recorder.py
@@ -1,0 +1,82 @@
+"""Helpers for recording execution traces."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from agent_harness.trace import Trace
+
+
+class TraceRecorder:
+    """Incrementally build a Trace object."""
+
+    def __init__(self) -> None:
+        """Create an empty trace recorder."""
+        self._messages: list[dict[str, Any]] = []
+        self._tool_calls: list[dict[str, Any]] = []
+        self._events: list[dict[str, Any]] = []
+
+    def add_message(self, role: str, content: str) -> None:
+        """Record a conversation message."""
+        if not isinstance(role, str) or not role.strip():
+            raise ValueError("role must be a non-empty string")
+
+        if not isinstance(content, str):
+            raise ValueError("content must be a string")
+
+        self._messages.append({"role": role.strip(), "content": content})
+
+    def add_tool_call(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> None:
+        """Record a tool call."""
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("tool name must be a non-empty string")
+
+        if arguments is None:
+            arguments = {}
+
+        if not isinstance(arguments, dict):
+            raise ValueError("tool call arguments must be an object")
+
+        self._tool_calls.append(
+            {
+                "name": name.strip(),
+                "arguments": deepcopy(arguments),
+            }
+        )
+
+    def add_event(
+        self,
+        event_type: str,
+        event_id: str | None = None,
+        **fields: Any,
+    ) -> None:
+        """Record a structured trace event."""
+        if not isinstance(event_type, str) or not event_type.strip():
+            raise ValueError("event type must be a non-empty string")
+
+        event: dict[str, Any] = {"type": event_type.strip()}
+
+        if event_id is not None:
+            if not isinstance(event_id, str) or not event_id.strip():
+                raise ValueError("event id must be a non-empty string")
+            event["id"] = event_id.strip()
+
+        event.update(deepcopy(fields))
+        self._events.append(event)
+
+    def to_trace(self) -> Trace:
+        """Convert the recorded data into a Trace."""
+        return Trace(
+            messages=deepcopy(self._messages),
+            tool_calls=deepcopy(self._tool_calls),
+            events=deepcopy(self._events),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the recorded data into a JSON-serializable dictionary."""
+        return self.to_trace().to_dict()

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,0 +1,134 @@
+"""Tests for trace recording helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_harness.recorder import TraceRecorder
+from agent_harness.trace import Trace
+
+
+def test_empty_recorder_returns_empty_trace_shape():
+    recorder = TraceRecorder()
+
+    trace = recorder.to_trace()
+
+    assert isinstance(trace, Trace)
+    assert trace.to_dict() == {
+        "messages": [],
+        "tool_calls": [],
+        "events": [],
+    }
+
+
+def test_add_message_strips_role_and_preserves_content():
+    recorder = TraceRecorder()
+
+    recorder.add_message(" user ", "")
+
+    assert recorder.to_dict()["messages"] == [
+        {
+            "role": "user",
+            "content": "",
+        }
+    ]
+
+
+def test_add_tool_call_strips_name_and_deep_copies_arguments():
+    recorder = TraceRecorder()
+    arguments = {"to": "attacker@example.com"}
+
+    recorder.add_tool_call(" send_email ", arguments)
+    arguments["to"] = "changed@example.com"
+
+    assert recorder.to_dict()["tool_calls"] == [
+        {
+            "name": "send_email",
+            "arguments": {
+                "to": "attacker@example.com",
+            },
+        }
+    ]
+
+
+def test_add_tool_call_defaults_arguments_to_empty_object():
+    recorder = TraceRecorder()
+
+    recorder.add_tool_call("send_email")
+
+    assert recorder.to_dict()["tool_calls"] == [
+        {
+            "name": "send_email",
+            "arguments": {},
+        }
+    ]
+
+
+def test_add_event_strips_type_and_id_and_deep_copies_fields():
+    recorder = TraceRecorder()
+    source = {"trust": "untrusted"}
+
+    recorder.add_event(" goal ", " summarize_document ", source=source)
+    source["trust"] = "trusted"
+
+    assert recorder.to_dict()["events"] == [
+        {
+            "type": "goal",
+            "id": "summarize_document",
+            "source": {
+                "trust": "untrusted",
+            },
+        }
+    ]
+
+
+@pytest.mark.parametrize("role", ["", "   ", 123, None])
+def test_add_message_rejects_invalid_role(role):
+    recorder = TraceRecorder()
+
+    with pytest.raises(ValueError, match="role must be a non-empty string"):
+        recorder.add_message(role, "hello")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("content", [123, None, [], {}])
+def test_add_message_rejects_non_string_content(content):
+    recorder = TraceRecorder()
+
+    with pytest.raises(ValueError, match="content must be a string"):
+        recorder.add_message("user", content)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("name", ["", "   ", 123, None])
+def test_add_tool_call_rejects_invalid_name(name):
+    recorder = TraceRecorder()
+
+    with pytest.raises(ValueError, match="tool name must be a non-empty string"):
+        recorder.add_tool_call(name)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("arguments", ["bad", 123, [], None])
+def test_add_tool_call_rejects_non_object_arguments(arguments):
+    recorder = TraceRecorder()
+
+    if arguments is None:
+        recorder.add_tool_call("send_email", arguments)
+        return
+
+    with pytest.raises(ValueError, match="tool call arguments must be an object"):
+        recorder.add_tool_call("send_email", arguments)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("event_type", ["", "   ", 123, None])
+def test_add_event_rejects_invalid_event_type(event_type):
+    recorder = TraceRecorder()
+
+    with pytest.raises(ValueError, match="event type must be a non-empty string"):
+        recorder.add_event(event_type)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("event_id", ["", "   ", 123])
+def test_add_event_rejects_invalid_event_id(event_id):
+    recorder = TraceRecorder()
+
+    with pytest.raises(ValueError, match="event id must be a non-empty string"):
+        recorder.add_event("goal", event_id)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Adds `TraceRecorder`, a small helper for building harness-compatible execution traces.

This provides a simpler integration path for Python agent targets and future framework adapters by recording:

- messages
- tool calls
- structured events

The recorder validates basic input, strips stable identifiers, deep-copies mutable data when recording, and returns the existing `Trace` model.

## Validation

```bash
python -m pytest tests/test_recorder.py
python -m pytest