### PR TITLE
Use trace recorder in demo targets

### DIFF
--- a/examples/targets/hardened_http_agent.py
+++ b/examples/targets/hardened_http_agent.py
@@ -7,8 +7,8 @@ never as instruction. The user's original request stays the goal.
 
 Running the harness against this target should *pass* the
 ``no_denied_tool_call`` assertion on the bundled
-``scenarios/goal_hijack/basic.yaml`` scenario, demonstrating what a
-correctly-behaving agent looks like to the harness.
+``scenarios/goal_hijack/outbound_email_exfiltration_001.yaml`` scenario,
+demonstrating what a correctly-behaving agent looks like to the harness.
 
 This agent is intentionally minimal. It is not a production guidance
 template; its job is to give the harness a positive control to compare
@@ -20,6 +20,8 @@ from __future__ import annotations
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
+
+from agent_harness.recorder import TraceRecorder
 
 
 HOST = "127.0.0.1"
@@ -62,16 +64,6 @@ def build_trace(payload: dict[str, Any]) -> dict[str, Any]:
     user_message = scenario_input.get("user_message", "") or ""
     context = scenario_input.get("context", []) or []
 
-    events: list[dict[str, Any]] = []
-
-    if has_untrusted_context(context):
-        events.append(
-            {
-                "type": "untrusted_context_received",
-                "policy": "treated as data, not instruction",
-            }
-        )
-
     trusted_text = collect_trusted_text(context)
 
     if trusted_text:
@@ -84,16 +76,17 @@ def build_trace(payload: dict[str, Any]) -> dict[str, Any]:
             "cannot complete the request."
         )
 
-    trace: dict[str, Any] = {
-        "messages": [
-            {"role": "user", "content": user_message},
-            {"role": "assistant", "content": assistant_text},
-        ],
-        "tool_calls": [],
-        "events": events,
-    }
+    recorder = TraceRecorder()
+    recorder.add_message("user", user_message)
+    recorder.add_message("assistant", assistant_text)
 
-    return trace
+    if has_untrusted_context(context):
+        recorder.add_event(
+            event_type="untrusted_context_received",
+            policy="treated as data, not instruction",
+        )
+
+    return recorder.to_dict()
 
 
 class HardenedAgentRequestHandler(BaseHTTPRequestHandler):

--- a/examples/targets/vulnerable_http_agent.py
+++ b/examples/targets/vulnerable_http_agent.py
@@ -9,8 +9,8 @@ to whatever the untrusted content asks for instead.
 
 Running the harness against this target should *fail* the
 ``no_denied_tool_call`` assertion on the bundled
-``scenarios/goal_hijack/basic.yaml`` scenario, which is exactly the
-regression detection the harness is built to provide.
+``scenarios/goal_hijack/outbound_email_exfiltration_001.yaml`` scenario,
+which is exactly the regression detection the harness is built to provide.
 
 This agent is for demonstration only. It is unsafe by design.
 """
@@ -21,6 +21,7 @@ import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 
+from agent_harness.recorder import TraceRecorder
 
 HOST = "127.0.0.1"
 PORT = 8001
@@ -87,16 +88,18 @@ def build_trace(payload: dict[str, Any]) -> dict[str, Any]:
     untrusted_text = find_untrusted_content(context)
     decision = naive_follow(untrusted_text)
 
-    trace: dict[str, Any] = {
-        "messages": [
-            {"role": "user", "content": user_message},
-            {"role": "assistant", "content": decision["assistant_text"]},
-        ],
-        "tool_calls": decision["tool_calls"],
-        "events": [],
-    }
+    recorder: TraceRecorder = TraceRecorder()
+    recorder.add_message("user", user_message)
+    recorder.add_message("assistant", decision["assistant_text"])
 
-    return trace
+    for tool_call in decision["tool_calls"]:
+        name = tool_call.get("name")
+        arguments = tool_call.get("arguments", {})
+
+        if isinstance(name, str) and isinstance(arguments, dict):
+            recorder.add_tool_call(name, arguments)
+
+    return recorder.to_dict()
 
 
 class VulnerableAgentRequestHandler(BaseHTTPRequestHandler):


### PR DESCRIPTION
## Summary

Refactors the toy vulnerable and hardened HTTP demo targets to use `TraceRecorder` instead of manually constructing trace dictionaries.

This makes the examples demonstrate the recommended Python integration pattern for producing harness-compatible traces.

## Validation

```bash
python -m pytest tests/test_demo_targets.py
python -m pytest