### PR TITLE
feat: add GitHub Actions CI example for security regression testing

### DIFF
--- a/.github/workflows/security-regression.yml
+++ b/.github/workflows/security-regression.yml
@@ -1,0 +1,56 @@
+name: Agent Security Regression
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  security-regression:
+    name: Run security regression scenarios
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install harness
+        run: python -m pip install -e .
+
+      - name: Create results directory
+        run: mkdir -p results
+
+      - name: Validate scenarios
+        run: |
+          agent-harness validate scenarios/goal_hijack/basic.yaml
+          agent-harness validate scenarios/goal_hijack/outbound_email_exfiltration_001.yaml
+
+      - name: Run goal hijack scenario (basic)
+        run: |
+          agent-harness run scenarios/goal_hijack/basic.yaml \
+            --trace-file examples/traces/no_denied_tool_call.json \
+            --out results/goal_hijack_basic.json
+
+      - name: Run outbound email exfiltration scenario
+        run: |
+          agent-harness run scenarios/goal_hijack/outbound_email_exfiltration_001.yaml \
+            --trace-file examples/traces/no_denied_tool_call.json \
+            --out results/goal_hijack_exfiltration.json
+
+      - name: Upload result artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-results
+          path: results/

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -1,0 +1,90 @@
+# CI with GitHub Actions
+
+The workflow runs on every push to `main` and on every pull request targeting
+`main`. It installs the harness, validates scenario files, and checks
+assertions against pre-recorded traces. If an assertion fails, the workflow
+fails and the regression is caught before merging.
+
+## Workflow file location
+`.github/workflows/security-regression.yml`
+
+## How pass and fail work
+
+The harness CLI exits with a non-zero code when an assertion fails. GitHub
+Actions treats any non-zero exit code as a step failure, which fails the job
+and marks the workflow red.
+
+Example: a scenario has `denied_tools: [send_email]` and the trace contains
+a `send_email` tool call. The `no_denied_tool_call` assertion fires, the CLI
+exits with code 1, the step fails. No extra scripting needed.
+
+## Run mode
+
+This workflow uses `--trace-file` mode. It checks assertions against a
+pre-recorded JSON trace without starting a live agent.
+
+Good fit for CI because:
+
+- no server needs to start
+- no API keys required
+- same input always produces the same result
+
+To test against a live agent instead, see `--live` mode in the README. That
+requires an HTTP agent server running before the harness is invoked.
+
+## What the workflow does
+
+1. Check out the repository
+2. Set up Python 3.11
+3. Install the harness with `pip install -e .`
+4. Create the `results/` directory
+5. Validate each scenario file with `agent-harness validate`
+6. Run each scenario against its trace file with `agent-harness run`
+7. Upload result JSON files as artifacts
+
+## Viewing results
+
+Result JSON files are uploaded as a workflow artifact named
+`regression-results` after every run, including failed ones.
+
+To find them:
+
+1. Go to the Actions tab in your repository
+2. Click the workflow run
+3. Scroll to Artifacts
+4. Download `regression-results`
+
+Each file shows the scenario ID, result status, which assertions ran, and
+the evidence for any failure.
+
+## Adapting this for your own project
+
+1. Copy `.github/workflows/security-regression.yml` to your repository
+2. Put your scenario files in a `scenarios/` directory
+3. Put your trace files in `examples/traces/`
+4. Update the `agent-harness validate` and `agent-harness run` commands to
+   point to your files
+5. Add one `agent-harness run` step per scenario
+
+## Adding a new scenario
+
+When you write a new scenario file, add two things to the workflow:
+
+1. An `agent-harness validate` call for the new file
+2. An `agent-harness run` step with the scenario and its trace file
+
+```yaml
+- name: Validate my new scenario
+  run: agent-harness validate scenarios/my_category/my_scenario.yaml
+
+- name: Run my new scenario
+  run: |
+    agent-harness run scenarios/my_category/my_scenario.yaml \
+      --trace-file examples/traces/my_trace.json \
+      --out results/my_scenario.json
+```
+
+## Related
+
+- [Trace format](trace-format.md)
+- [README](../README.md)

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -1,6 +1,7 @@
 # CI with GitHub Actions
 
-The workflow runs on every push to `main` and on every pull request targeting
+When copied into `.github/workflows/security-regression.yml`, this workflow runs 
+on every push to `main` and on every pull request targeting
 `main`. It installs the harness, validates scenario files, runs assertions
 against pre-recorded traces, and explicitly checks the result JSON to fail
 the job if any regression was detected.

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -21,10 +21,11 @@ or `error`.
 
 The workflow handles this by adding an explicit result-checking step after
 all the `agent-harness run` steps. It reads every JSON file in `results/`,
-looks for `"result": "fail"`, and calls `sys.exit(1)` if any are found. That
-is what actually fails the job.
+looks for `"result": "fail"` or `"result": "error"`, and calls `sys.exit(1)`
+if any are found. That is what actually fails the job.
 
-A result of `"error"` (for example, from a malformed trace) will not break the build.
+A result of `"error"` means the harness did not complete the regression check
+correctly, so this example treats it as a CI failure.
 
 ```
 harness writes JSON → result-checking step reads JSON → step exits 1 → job fails
@@ -37,9 +38,10 @@ Some assertions are recognized by the harness but not fully implemented yet.
 it comes back as `not_run` rather than `pass` or `fail`.
 
 The basic goal-hijack scenario includes `no_secret_disclosure`, so you will
-see `not_run` in that result. This is expected. The result-checking step only
-treats `"result": "fail"` as a CI failure, so `not_run` does not break the
-build. The README documents which assertions are currently implemented.
+see `not_run` in that result. This is expected. The result-checking step treats
+`"result": "fail"` and `"result": "error"` as CI failures, but allows
+`"not_run"` so recognized-but-unimplemented assertions do not break the build.
+The README documents which assertions are currently implemented.
 
 ## Run mode
 
@@ -60,7 +62,7 @@ would need an HTTP agent server running before the harness step fires.
 4. Create the `results/` directory
 5. Validate each scenario file with `agent-harness validate`
 6. Run each scenario with `agent-harness run --trace-file ... --out results/....json`
-7. Read every file in `results/` and exit 1 if any has `"result": "fail"`
+7. Read every file in `results/` and exit 1 if any has `"result": "fail"` or `"result": "error"`
 8. Upload result JSON files as artifacts (runs even when step 7 fails, because of `if: always()`)
 
 ## Viewing results

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -1,51 +1,73 @@
 # CI with GitHub Actions
 
 The workflow runs on every push to `main` and on every pull request targeting
-`main`. It installs the harness, validates scenario files, and checks
-assertions against pre-recorded traces. If an assertion fails, the workflow
-fails and the regression is caught before merging.
+`main`. It installs the harness, validates scenario files, runs assertions
+against pre-recorded traces, and explicitly checks the result JSON to fail
+the job if any regression was detected.
 
-## Workflow file location
-`.github/workflows/security-regression.yml`
+## Where the example workflow lives
 
-## How pass and fail work
+The example workflow is at:
 
-The harness CLI exits with a non-zero code when an assertion fails. GitHub
-Actions treats any non-zero exit code as a step failure, which fails the job
-and marks the workflow red.
+```
+docs/examples/github-actions/security-regression.yml
+```
 
-Example: a scenario has `denied_tools: [send_email]` and the trace contains
-a `send_email` tool call. The `no_denied_tool_call` assertion fires, the CLI
-exits with code 1, the step fails. No extra scripting needed.
+## How pass and fail actually work
+
+`agent-harness run` writes machine-readable result JSON to the path you give
+`--out`. The `result` field in that JSON will be `pass`, `fail`, `not_run`,
+or `error`.
+
+The workflow handles this by adding an explicit result-checking step after
+all the `agent-harness run` steps. It reads every JSON file in `results/`,
+looks for `"result": "fail"`, and calls `sys.exit(1)` if any are found. That
+is what actually fails the job.
+
+A result of `"error"` (for example, from a malformed trace) will not break the build.
+
+```
+harness writes JSON → result-checking step reads JSON → step exits 1 → job fails
+```
+
+## A note on `not_run`
+
+Some assertions are recognized by the harness but not fully implemented yet.
+`no_secret_disclosure` is one example. When an assertion has no implementation,
+it comes back as `not_run` rather than `pass` or `fail`.
+
+The basic goal-hijack scenario includes `no_secret_disclosure`, so you will
+see `not_run` in that result. This is expected. The result-checking step only
+treats `"result": "fail"` as a CI failure, so `not_run` does not break the
+build. The README documents which assertions are currently implemented.
 
 ## Run mode
 
-This workflow uses `--trace-file` mode. It checks assertions against a
+This workflow uses `--trace-file` mode. It evaluates assertions against a
 pre-recorded JSON trace without starting a live agent.
 
-Good fit for CI because:
+That makes it a good fit for CI: no server to start, no API keys required,
+and the same input always produces the same result.
 
-- no server needs to start
-- no API keys required
-- same input always produces the same result
-
-To test against a live agent instead, see `--live` mode in the README. That
-requires an HTTP agent server running before the harness is invoked.
+To test against a live agent instead, see `--live` mode in the README. You
+would need an HTTP agent server running before the harness step fires.
 
 ## What the workflow does
 
 1. Check out the repository
 2. Set up Python 3.11
-3. Install the harness with `pip install -e .`
+3. Install the harness with `python -m pip install -e .`
 4. Create the `results/` directory
 5. Validate each scenario file with `agent-harness validate`
-6. Run each scenario against its trace file with `agent-harness run`
-7. Upload result JSON files as artifacts
+6. Run each scenario with `agent-harness run --trace-file ... --out results/....json`
+7. Read every file in `results/` and exit 1 if any has `"result": "fail"`
+8. Upload result JSON files as artifacts (runs even when step 7 fails, because of `if: always()`)
 
 ## Viewing results
 
 Result JSON files are uploaded as a workflow artifact named
-`regression-results` after every run, including failed ones.
+`regression-results` after every run. The artifact upload step has
+`if: always()`, so you get the files whether the job passed or failed.
 
 To find them:
 
@@ -54,24 +76,26 @@ To find them:
 3. Scroll to Artifacts
 4. Download `regression-results`
 
-Each file shows the scenario ID, result status, which assertions ran, and
+Each file contains the scenario ID, result status, which assertions ran, and
 the evidence for any failure.
 
 ## Adapting this for your own project
 
-1. Copy `.github/workflows/security-regression.yml` to your repository
+1. Copy `docs/examples/github-actions/security-regression.yml` into
+   `.github/workflows/security-regression.yml` in your repository
 2. Put your scenario files in a `scenarios/` directory
 3. Put your trace files in `examples/traces/`
 4. Update the `agent-harness validate` and `agent-harness run` commands to
    point to your files
 5. Add one `agent-harness run` step per scenario
 
+The result-checking step at the end works across however many scenarios you
+add. It globs `results/*.json`, so you do not need to update it when you add
+new scenarios.
+
 ## Adding a new scenario
 
-When you write a new scenario file, add two things to the workflow:
-
-1. An `agent-harness validate` call for the new file
-2. An `agent-harness run` step with the scenario and its trace file
+When you write a new scenario, add two things to the workflow:
 
 ```yaml
 - name: Validate my new scenario
@@ -83,6 +107,8 @@ When you write a new scenario file, add two things to the workflow:
       --trace-file examples/traces/my_trace.json \
       --out results/my_scenario.json
 ```
+
+The result-checking step picks up the new output file automatically.
 
 ## Related
 

--- a/docs/examples/github-actions/security-regression.yml
+++ b/docs/examples/github-actions/security-regression.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -48,9 +48,28 @@ jobs:
             --trace-file examples/traces/no_denied_tool_call.json \
             --out results/goal_hijack_exfiltration.json
 
+      - name: Fail if any regression result failed
+        run: |
+          python - <<'PY'
+          import json
+          import pathlib
+          import sys
+          failed = []
+          for path in pathlib.Path("results").glob("*.json"):
+              result = json.loads(path.read_text(encoding="utf-8"))
+              if result.get("result") == "fail":
+                  failed.append(f"{path}: {result.get('scenario_id')} failed")
+          if failed:
+              print("Security regression failures detected:")
+              for item in failed:
+                  print(f"- {item}")
+              sys.exit(1)
+          print("No failing security regression results detected.")
+          PY
+
       - name: Upload result artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: regression-results
           path: results/

--- a/docs/examples/github-actions/security-regression.yml
+++ b/docs/examples/github-actions/security-regression.yml
@@ -48,23 +48,29 @@ jobs:
             --trace-file examples/traces/no_denied_tool_call.json \
             --out results/goal_hijack_exfiltration.json
 
-      - name: Fail if any regression result failed
+      - name: Fail if any regression result failed or errored
         run: |
           python - <<'PY'
           import json
           import pathlib
           import sys
+
           failed = []
+
           for path in pathlib.Path("results").glob("*.json"):
               result = json.loads(path.read_text(encoding="utf-8"))
-              if result.get("result") == "fail":
-                  failed.append(f"{path}: {result.get('scenario_id')} failed")
+              if result.get("result") in {"fail", "error"}:
+                  failed.append(
+                      f"{path}: {result.get('scenario_id')} returned {result.get('result')}"
+                  )
+
           if failed:
               print("Security regression failures detected:")
               for item in failed:
                   print(f"- {item}")
               sys.exit(1)
-          print("No failing security regression results detected.")
+
+          print("No failing or errored security regression results detected.")
           PY
 
       - name: Upload result artifacts


### PR DESCRIPTION
Closes #18 

## What this adds

- `.github/workflows/security-regression.yml` : a GitHub Actions workflow
  that runs security regression scenarios on every push and pull request
- `docs/ci-github-actions.md` : explains how the workflow works, how pass
  and fail are triggered, and how to adapt it for another project

## Approach

Uses `--trace-file` mode so the workflow requires no live agent, no API keys,
and produces deterministic results on every run. The example uses the
scenarios and trace files already present in the repository.

## Testing

Ran all commands locally before opening this PR.