### PR TITLE
Add Python callable adapter API

### DIFF
--- a/src/agent_harness/adapters.py
+++ b/src/agent_harness/adapters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import json
 from typing import Any
 from urllib import error, request
@@ -9,19 +10,30 @@ from urllib import error, request
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace, TraceValidationError
 
+
 class AdapterError(RuntimeError):
-    """Raised when a live target adapter fails"""
-    
-def build_http_request_body(scenario: Scenario) -> dict[str, Any]:
-    """Build the JSON request body sent to an HTTP target."""
+    """Raised when a target adapter fails."""
+
+
+def build_target_payload(scenario: Scenario) -> dict[str, Any]:
+    """Build the payload sent to a target adapter."""
     return {
         "scenario_id": scenario.id,
         "input": scenario.raw["input"],
     }
 
+
+def _trace_from_dict(trace_data: dict[str, Any], error_prefix: str) -> Trace:
+    """Convert trace-shaped dictionary data into a Trace."""
+    try:
+        return Trace.from_dict(trace_data)
+    except TraceValidationError as exc:
+        raise AdapterError(f"{error_prefix}: {exc}") from exc
+
+
 def run_http_target(scenario: Scenario, target_url: str) -> Trace:
     """Run a scenario against an HTTP target and return its trace."""
-    body = build_http_request_body(scenario)
+    body = build_target_payload(scenario)
     request_data = json.dumps(body).encode("utf-8")
     http_request = request.Request(
         target_url,
@@ -32,21 +44,48 @@ def run_http_target(scenario: Scenario, target_url: str) -> Trace:
         },
         method="POST",
     )
-    
+
     try:
         with request.urlopen(http_request, timeout=30) as response:
             response_text = response.read().decode("utf-8")
     except error.URLError as exc:
         raise AdapterError(f"HTTP target request failed: {exc}") from exc
-    
+
     try:
         trace_data = json.loads(response_text)
     except json.JSONDecodeError as exc:
         raise AdapterError(f"HTTP target returned invalid JSON: {exc}") from exc
-    
-    try:
-        return Trace.from_dict(trace_data)
-    except TraceValidationError as exc:
-        raise AdapterError(f"HTTP target returned invalid trace: {exc}") from exc 
-    
 
+    if not isinstance(trace_data, dict):
+        raise AdapterError(
+            f"HTTP target returned non-object JSON: got {type(trace_data).__name__}"
+        )
+
+    return _trace_from_dict(trace_data, "HTTP target returned invalid trace")
+
+
+def run_python_callable_target(
+    scenario: Scenario,
+    agent_callable: Callable[[dict[str, Any]], Trace | dict[str, Any]],
+) -> Trace:
+    """Run a scenario against a Python callable target and return its trace."""
+    payload = build_target_payload(scenario)
+
+    try:
+        trace_result = agent_callable(payload)
+    except Exception as exc:
+        raise AdapterError(f"Python callable raised an exception: {exc}") from exc
+
+    if isinstance(trace_result, Trace):
+        return trace_result
+
+    if not isinstance(trace_result, dict):
+        raise AdapterError(
+            "Python callable must return a Trace or trace-shaped dictionary; "
+            f"got {type(trace_result).__name__}"
+        )
+
+    return _trace_from_dict(
+        trace_result,
+        "Python callable returned invalid trace",
+    )

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,101 @@
+"""Tests for target adapters."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_harness.adapters import AdapterError, run_python_callable_target
+from agent_harness.trace import Trace
+from test_assertions import make_scenario
+
+
+def test_python_callable_receives_target_payload():
+    scenario = make_scenario(assertions=[])
+    observed_payload = {}
+
+    def fake_agent(payload):
+        observed_payload.update(payload)
+        return {
+            "messages": [],
+            "tool_calls": [],
+            "events": [],
+        }
+
+    trace = run_python_callable_target(scenario, fake_agent)
+
+    assert isinstance(trace, Trace)
+    assert observed_payload == {
+        "scenario_id": scenario.id,
+        "input": scenario.raw["input"],
+    }
+
+
+def test_python_callable_accepts_trace_return():
+    scenario = make_scenario(assertions=[])
+
+    expected_trace = Trace(
+        messages=[{"role": "assistant", "content": "ok"}],
+        tool_calls=[],
+        events=[],
+    )
+
+    def fake_agent(payload):
+        return expected_trace
+
+    trace = run_python_callable_target(scenario, fake_agent)
+
+    assert trace is expected_trace
+
+
+def test_python_callable_accepts_trace_shaped_dict_return():
+    scenario = make_scenario(assertions=[])
+
+    def fake_agent(payload):
+        return {
+            "messages": [{"role": "assistant", "content": "ok"}],
+            "tool_calls": [],
+            "events": [],
+        }
+
+    trace = run_python_callable_target(scenario, fake_agent)
+
+    assert trace.to_dict() == {
+        "messages": [{"role": "assistant", "content": "ok"}],
+        "tool_calls": [],
+        "events": [],
+    }
+
+
+def test_python_callable_wraps_exception_in_adapter_error():
+    scenario = make_scenario(assertions=[])
+
+    def broken_agent(payload):
+        raise RuntimeError("boom")
+
+    with pytest.raises(AdapterError, match="Python callable raised an exception"):
+        run_python_callable_target(scenario, broken_agent)
+
+
+@pytest.mark.parametrize("bad_return", ["not a dict", 123, [], None])
+def test_python_callable_rejects_invalid_return_type(bad_return):
+    scenario = make_scenario(assertions=[])
+
+    def bad_agent(payload):
+        return bad_return
+
+    with pytest.raises(AdapterError, match="Trace or trace-shaped dictionary"):
+        run_python_callable_target(scenario, bad_agent)
+
+
+def test_python_callable_wraps_invalid_trace_shape():
+    scenario = make_scenario(assertions=[])
+
+    def malformed_agent(payload):
+        return {
+            "messages": [],
+            "tool_calls": "should be a list",
+            "events": [],
+        }
+
+    with pytest.raises(AdapterError, match="Python callable returned invalid trace"):
+        run_python_callable_target(scenario, malformed_agent)


### PR DESCRIPTION
## Summary

Adds a Python callable adapter API for running a scenario against a local Python function without requiring an HTTP server.

The callable receives the same scenario-shaped payload as the HTTP adapter:

```json
{
  "scenario_id": "...",
  "input": {}
}

Closes #48 