### PR TITLE
Validate expected goal for goal integrity assertions

### DIFF
--- a/src/agent_harness/scenario.py
+++ b/src/agent_harness/scenario.py
@@ -124,6 +124,15 @@ def validate_scenario_data(data: Any) -> Scenario:
                 f"assertions[{index}].type must be a non-empty string"
             )
 
+        assertion_type = assertion_type.strip()
+        if assertion_type == "goal_integrity":
+            expected_goal = assertion.get("expected_goal")
+            if not isinstance(expected_goal, str) or not expected_goal.strip():
+                raise ScenarioValidationError(
+                    f"assertions[{index}].expected_goal must be a non-empty string "
+                    "for goal_integrity assertions"
+                )
+
     return Scenario(
         id=scenario_id,
         title=title,

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -4,7 +4,27 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from agent_harness.scenario import load_scenario
+import pytest
+
+from agent_harness.scenario import (
+    ScenarioValidationError,
+    load_scenario,
+    validate_scenario_data,
+)
+
+
+def _minimal_scenario(assertions):
+    return {
+        "id": "goal-hijack-basic",
+        "title": "Goal hijack basic",
+        "category": "goal_hijack",
+        "severity": "medium",
+        "target": {},
+        "input": {},
+        "expected": {},
+        "assertions": assertions,
+    }
+
 
 def test_all_bundled_scenarios_validate():
     scenario_paths = sorted(Path("scenarios").rglob("*.yaml"))
@@ -15,5 +35,49 @@ def test_all_bundled_scenarios_validate():
         load_scenario(scenario_path)
 
 
+def test_goal_integrity_assertion_validates_with_expected_goal():
+    scenario = validate_scenario_data(
+        _minimal_scenario(
+            [{"type": "goal_integrity", "expected_goal": "summarize_document"}]
+        )
+    )
+
+    assert scenario.id == "goal-hijack-basic"
+
+
+def test_goal_integrity_assertion_requires_expected_goal():
+    with pytest.raises(
+        ScenarioValidationError,
+        match="expected_goal must be a non-empty string",
+    ):
+        validate_scenario_data(_minimal_scenario([{"type": "goal_integrity"}]))
+
+
+def test_goal_integrity_assertion_rejects_blank_expected_goal():
+    with pytest.raises(
+        ScenarioValidationError,
+        match="expected_goal must be a non-empty string",
+    ):
+        validate_scenario_data(
+            _minimal_scenario([{"type": "goal_integrity", "expected_goal": "   "}])
+        )
+
+
+def test_goal_integrity_assertion_rejects_non_string_expected_goal():
+    with pytest.raises(
+        ScenarioValidationError,
+        match="expected_goal must be a non-empty string",
+    ):
+        validate_scenario_data(
+            _minimal_scenario([{"type": "goal_integrity", "expected_goal": 123}])
+        )
+
+
+def test_other_assertion_types_do_not_require_expected_goal():
+    scenario = validate_scenario_data(
+        _minimal_scenario([{"type": "no_denied_tool_call"}])
+    )
+
+    assert scenario.id == "goal-hijack-basic"
 
 


### PR DESCRIPTION
## Summary

Fixes #37.

This PR updates scenario validation so `goal_integrity` assertions require a non-empty assertion-level `expected_goal`.

## Problem

`goal_integrity` depends on assertion-level configuration:

```yaml
assertions:
  - type: goal_integrity
    expected_goal: summarize_document
```

Before this change, `scenario.py` only validated that each assertion had a non-empty `type`. That allowed invalid scenarios like this to pass validation:

```yaml
assertions:
  - type: goal_integrity
```

The missing `expected_goal` was only detected later during assertion evaluation, where the assertion returned `not_run`. Because this is a scenario configuration issue, it should fail during scenario validation.

## Solution

Added type-specific validation in `src/agent_harness/scenario.py`.

When an assertion has:

```yaml
type: goal_integrity
```

the validator now requires `expected_goal` to:

- be present
- be a string
- contain a non-empty value after trimming whitespace

If the requirement is not met, validation raises `ScenarioValidationError` with a clear message pointing to the invalid assertion index.

## Files Changed

- `src/agent_harness/scenario.py`

## Validation

I validated the change with the following commands.

### Syntax check

```powershell
python -m py_compile src/agent_harness/scenario.py
```

Result: passed.

### Diff whitespace check

```powershell
git diff --check
```

Result: passed.

### Scenario validation

Because the active Python environment did not have `PyYAML` installed, I installed it into a temporary isolated directory and used it only for validation:

```powershell
$deps = Join-Path $env:TEMP ("agent_harness_validation_deps_" + [guid]::NewGuid().ToString("N"))
python -m pip install --quiet --target $deps "PyYAML>=6.0.0"
$env:PYTHONPATH = "src;$deps"

Get-ChildItem -Path scenarios -Recurse -Filter *.yaml | ForEach-Object {
    python -m agent_harness.cli validate $_.FullName
    if ($LASTEXITCODE -ne 0) {
        exit $LASTEXITCODE
    }
}
```

Result: all bundled scenarios validated successfully.

Validated scenarios:

- `approval_bypass.claimed_preauthorization_root_password_001`
- `goal_hijack.basic_001`
- `goal_hijack.outbound_email_exfiltration_001`
- `prompt_injection.direct_instruction_override_001`
- `unsafe_tool_execution.unsafe_tool_invocation_attempt_001`
