### PR TITLE
Add CLI support for OpenAI Agents SDK targets

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -391,6 +391,23 @@ The adapter records:
 
 The adapter returns a harness `Trace`. It does not evaluate assertions or decide pass/fail.
 
+CLI usage:
+
+```bash
+agent-harness run scenarios/goal_hijack/basic.yaml \
+  --openai-agent my_agent_module:agent
+```
+
+Optional max turns:
+
+```bash
+agent-harness run scenarios/goal_hijack/basic.yaml \
+  --openai-agent my_agent_module:agent \
+  --openai-agent-max-turns 5
+```
+
+The `--openai-agent` value must use an explicit `module:object` import path. Scenario files should not contain Python import paths.
+
 Example Python usage:
 
 ```python

--- a/src/agent_harness/adapters.py
+++ b/src/agent_harness/adapters.py
@@ -32,6 +32,47 @@ def _trace_from_dict(trace_data: dict[str, Any], error_prefix: str) -> Trace:
         raise AdapterError(f"{error_prefix}: {exc}") from exc
 
 
+def load_python_object(import_path: str, target_description: str) -> Any:
+    """Load a Python object from a module:object import path."""
+    if not isinstance(import_path, str) or not import_path.strip():
+        raise AdapterError(f"{target_description} import path must be a non-empty string")
+
+    if ":" not in import_path:
+        raise AdapterError(
+            f"{target_description} must use 'module:object' format, "
+            f"got {import_path!r}"
+        )
+
+    module_name, object_name = import_path.split(":", 1)
+    module_name = module_name.strip()
+    object_name = object_name.strip()
+
+    if not module_name or not object_name:
+        raise AdapterError(
+            f"{target_description} must use 'module:object' format with both parts present"
+        )
+
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:
+        raise AdapterError(
+            f"Could not import {target_description} module {module_name!r}"
+        ) from exc
+
+    target: Any = module
+
+    try:
+        for attr in object_name.split("."):
+            target = getattr(target, attr)
+    except AttributeError as exc:
+        raise AdapterError(
+            f"{target_description} object {object_name!r} was not found "
+            f"in module {module_name!r}"
+        ) from exc
+
+    return target
+
+
 def load_python_callable(
     import_path: str,
 ) -> Callable[[dict[str, Any]], Trace | dict[str, Any]]:
@@ -45,32 +86,7 @@ def load_python_callable(
             f"got {import_path!r}"
         )
 
-    module_name, callable_name = import_path.split(":", 1)
-    module_name = module_name.strip()
-    callable_name = callable_name.strip()
-
-    if not module_name or not callable_name:
-        raise AdapterError(
-            "Python target must use 'module:function' format with both parts present"
-        )
-
-    try:
-        module = importlib.import_module(module_name)
-    except Exception as exc:
-        raise AdapterError(
-            f"Could not import Python target module {module_name!r}"
-        ) from exc
-
-    target: Any = module
-
-    try:
-        for attr in callable_name.split("."):
-            target = getattr(target, attr)
-    except AttributeError as exc:
-        raise AdapterError(
-            f"Python target callable {callable_name!r} was not found "
-            f"in module {module_name!r}"
-        ) from exc
+    target = load_python_object(import_path, "Python target")
 
     if not callable(target):
         raise AdapterError(f"Python target {import_path!r} is not callable")

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -10,6 +10,7 @@ from agent_harness.adapters import AdapterError
 from agent_harness.runner import (
     dry_run_scenario,
     run_scenario_live,
+    run_scenario_with_openai_agent,
     run_scenario_with_python_target,
     run_scenario_with_trace,
 )
@@ -82,6 +83,18 @@ def build_parser() -> argparse.ArgumentParser:
             "module:function format."
         ),
     )
+    run_parser.add_argument(
+        "--openai-agent",
+        help=(
+            "Run the scenario against an OpenAI Agents SDK Agent loaded from "
+            "a module:object import path."
+        ),
+    )
+    run_parser.add_argument(
+        "--openai-agent-max-turns",
+        type=int,
+        help="Optional max_turns value passed to the OpenAI Agents SDK runner.",
+    )
 
     return parser
 
@@ -110,12 +123,13 @@ def main() -> int:
             args.trace_file is not None,
             args.live,
             args.python_target is not None,
+            args.openai_agent is not None,
         ]
 
         if sum(bool(mode) for mode in selected_modes) != 1:
             parser.error(
                 "'run' requires exactly one of --dry-run, --trace-file, "
-                "--live, or --python-target"
+                "--live, --python-target, or --openai-agent"
             )
 
         if args.live and not args.target_url:
@@ -123,6 +137,15 @@ def main() -> int:
 
         if args.target_url and not args.live:
             parser.error("--target-url can only be used with --live")
+
+        if args.openai_agent_max_turns is not None and args.openai_agent is None:
+            parser.error("--openai-agent-max-turns can only be used with --openai-agent")
+
+        if (
+            args.openai_agent_max_turns is not None
+            and args.openai_agent_max_turns <= 0
+        ):
+            parser.error("--openai-agent-max-turns must be greater than zero")
 
         try:
             scenario = load_scenario(args.scenario_file)
@@ -144,6 +167,16 @@ def main() -> int:
                 result = run_scenario_with_python_target(
                     scenario,
                     args.python_target,
+                )
+            except AdapterError as exc:
+                print(f"adapter error: {exc}", file=sys.stderr)
+                return 1
+        elif args.openai_agent:
+            try:
+                result = run_scenario_with_openai_agent(
+                    scenario,
+                    args.openai_agent,
+                    max_turns=args.openai_agent_max_turns,
                 )
             except AdapterError as exc:
                 print(f"adapter error: {exc}", file=sys.stderr)

--- a/src/agent_harness/runner.py
+++ b/src/agent_harness/runner.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from agent_harness.adapters import (
     load_python_callable,
+    load_python_object,
     run_http_target,
     run_python_callable_target,
 )
 from agent_harness.assertions import evaluate_assertions
+from agent_harness.openai_agents_adapter import run_openai_agents_target
 from agent_harness.result import AssertionResult, HarnessResult, aggregate_assertion_results
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace
@@ -74,6 +76,31 @@ def run_scenario_with_python_target(
     """Run a scenario against a local Python callable target."""
     target_callable = load_python_callable(python_target)
     trace = run_python_callable_target(scenario, target_callable)
+    assertion_results = evaluate_assertions(scenario, trace)
+    top_level_result = aggregate_assertion_results(assertion_results)
+
+    return HarnessResult(
+        scenario_id=scenario.id,
+        mode="live",
+        result=top_level_result,
+        assertions=assertion_results,
+        trace=trace,
+    )
+
+
+def run_scenario_with_openai_agent(
+    scenario: Scenario,
+    openai_agent: str,
+    *,
+    max_turns: int | None = None,
+) -> HarnessResult:
+    """Run a scenario against an OpenAI Agents SDK Agent target."""
+    agent = load_python_object(openai_agent, "OpenAI Agents SDK target")
+    trace = run_openai_agents_target(
+        scenario,
+        agent,
+        max_turns=max_turns,
+    )
     assertion_results = evaluate_assertions(scenario, trace)
     top_level_result = aggregate_assertion_results(assertion_results)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -345,3 +345,110 @@ def test_run_python_target_returns_adapter_error_for_bad_import(
     assert captured.out == ""
     assert "adapter error:" in captured.err
     assert "Could not import Python target module" in captured.err
+
+
+def test_run_openai_agent_outputs_result_json(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    agents_module = tmp_path / "agents.py"
+    agents_module.write_text(
+        '''
+class Result:
+    def __init__(self, final_output):
+        self.final_output = final_output
+        self.new_items = []
+
+
+class Runner:
+    @staticmethod
+    def run_sync(agent, runner_input, **kwargs):
+        max_turns = kwargs.get("max_turns")
+        return Result(f"{agent.name}; max_turns={max_turns}")
+''',
+        encoding="utf-8",
+    )
+
+    target_module = tmp_path / "cli_openai_agent.py"
+    target_module.write_text(
+        '''
+class FakeAgent:
+    name = "fake-openai-agent"
+
+
+AGENT = FakeAgent()
+''',
+        encoding="utf-8",
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, "agents", raising=False)
+    monkeypatch.delitem(sys.modules, "cli_openai_agent", raising=False)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--openai-agent",
+            "cli_openai_agent:AGENT",
+            "--openai-agent-max-turns",
+            "5",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert result["scenario_id"] == "goal_hijack.basic_001"
+    assert result["mode"] == "live"
+    assert result["result"] == "pass"
+    assert result["assertions"][0]["id"] == "no_denied_tool_call"
+    assert result["assertions"][0]["result"] == "pass"
+    assert result["trace"]["messages"][1]["content"] == "fake-openai-agent; max_turns=5"
+    assert result["trace"]["tool_calls"] == []
+    assert result["trace"]["events"] == [
+        {
+            "type": "adapter",
+            "id": "openai_agents",
+        },
+        {
+            "type": "scenario",
+            "id": "goal_hijack.basic_001",
+        },
+    ]
+
+
+def test_run_openai_agent_returns_adapter_error_for_bad_import(
+    capsys,
+    monkeypatch,
+    tmp_path,
+):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--openai-agent",
+            "does_not_exist:AGENT",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "adapter error:" in captured.err
+    assert "Could not import OpenAI Agents SDK target module" in captured.err


### PR DESCRIPTION
## Summary

Adds CLI support for running scenarios against OpenAI Agents SDK targets through an explicit import path.

Example:

```bash
agent-harness run scenarios/goal_hijack/basic.yaml \
  --openai-agent my_agent_module:agent
```

Optional max turns:

```bash
agent-harness run scenarios/goal_hijack/basic.yaml \
  --openai-agent my_agent_module:agent \
  --openai-agent-max-turns 5
```

This PR adds:

- `--openai-agent`
- `--openai-agent-max-turns`
- generic `load_python_object(...)` support for loading non-callable Python objects
- runner integration through `run_scenario_with_openai_agent(...)`
- CLI tests using fake local modules and fake `agents.Runner`
- adapter documentation for CLI usage

The CLI keeps local code execution explicit through command-line flags. Scenario files do not contain Python import paths.

## Validation

```bash
python -m pytest tests/test_cli.py -v
python -m pytest
```

Closes #63 