### PR TITLE
Document AI-assisted contribution expectations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+Describe what changed and why.
+
+## Validation
+
+List the checks you ran (for example: tests, scenario validation, linting).
+
+- [ ] Tests/checks pass locally or in CI
+- [ ] Changes are scoped and reviewable
+
+## AI assistance disclosure (required if applicable)
+
+If AI tools were used to generate or substantially modify this
+contribution, complete this section.
+
+- Tools used:
+- AI-assisted areas (files/sections):
+- Human review performed:
+- Tests/checks run:
+
+I confirm I am responsible for all submitted changes and can explain
+how they work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,3 +41,48 @@ scenario/goal-hijack-basic
 docs/scenario-spec
 feature/http-agent-adapter
 fix/result-json-output
+```
+
+## AI-assisted contributions
+
+AI-assisted contributions are allowed, but they must be disclosed.
+
+This is a security-focused OWASP project. Human contributors remain
+responsible for every line they submit, including code, documentation,
+tests, and scenarios.
+
+Do not submit AI-generated output that you do not understand, cannot
+explain, or have not tested.
+
+If you used AI tooling such as Claude Code, ChatGPT, GitHub Copilot,
+Cursor, or similar tools to generate or substantially modify your
+contribution, disclose it in your pull request description.
+
+Your disclosure should include:
+
+- The tool(s) used
+- What parts were AI-assisted
+- How you reviewed the output
+- What tests/checks you ran
+
+AI tools must not be listed as the sole responsible author. The human
+submitter remains accountable.
+
+Maintainers may request changes or close pull requests that appear to
+be unreviewed generated output, are too large to review safely, or
+cannot be explained by the human submitter.
+
+To keep review quality high, prefer small and focused pull requests.
+
+### Suggested PR disclosure format
+
+If AI assistance was used, include a section like this in your PR body:
+
+```markdown
+## AI assistance disclosure
+
+- Tools used: <tool names>
+- AI-assisted areas: <files/sections>
+- Human review performed: <how you reviewed and validated>
+- Tests/checks run: <commands or CI checks>
+```


### PR DESCRIPTION
## Summary
Add clear policy guidance for AI-assisted contributions in this security-focused OWASP project.

### What changed
- Added an **AI-assisted contributions** section to CONTRIBUTING.md.
- Added .github/pull_request_template.md with an **AI assistance disclosure** section.
- Made human accountability explicit and encouraged smaller, focused PRs.
- Included a suggested disclosure format contributors can copy into PR descriptions.

## Why
This project is receiving AI-assisted PRs. AI-assisted development is acceptable, but contributors must disclose use and remain accountable for every submitted line.

## Acceptance criteria mapping
- [x] CONTRIBUTING.md includes an AI-assisted contribution policy
- [x] PR template includes AI assistance disclosure section
- [x] Policy makes human accountability explicit
- [x] Policy encourages smaller, focused PRs

Closes #41