### PR TITLE
docs: add AI-assisted contribution policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+Fixes #
+
+<!-- Add issue number above -->
+
+#### Describe the changes you have made in this PR -
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code or documentation ?**
+- [ ] No, I wrote all the code myself
+- [ ] Yes, I used AI assistance
+
+**If you used AI assistance, briefly describe:**
+- Tool(s) used:
+- Parts of the contribution that were AI-assisted:
+- How you reviewed the output:
+- Tests or checks I ran:
+
+---
+
+## Checklist before requesting a review
+- [ ] I have added proper PR title and linked to the issue
+- [ ] I have performed a self-review of my code
+- [ ] **I can explain the purpose of every documentation, function, class, and logic block I added**
+- [ ] I understand why my changes work and have tested them thoroughly
+- [ ] I have considered potential edge cases and how my code handles them
+- [ ] If it is a core feature, I have added thorough tests
+- [ ] My code follows the project's style guidelines and conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,3 +41,35 @@ scenario/goal-hijack-basic
 docs/scenario-spec
 feature/http-agent-adapter
 fix/result-json-output
+```
+
+## AI-assisted contributions
+
+### Policy
+
+AI-assisted contributions are allowed, but they must be disclosed.
+
+Contributors remain responsible for every line they submit. Do not submit AI-generated code, documentation, tests, or scenarios that you do not understand, cannot explain, or have not tested.
+
+If AI tools such as Claude Code, ChatGPT, GitHub Copilot, Cursor, or similar tools were used to generate or substantially modify a contribution, disclose that use in the pull request description.
+
+### Disclosure
+
+The disclosure should include:
+
+- The tool used
+- What parts of the contribution were AI-assisted
+- How the contributor reviewed the output
+- The tests or checks that were run
+
+AI tools should not be listed as the sole responsible author. The human submitter remains accountable for the contribution.
+
+### What maintainers may do
+
+Maintainers may request changes or close pull requests that:
+
+- Appear to be unreviewed generated output
+- Are too large to review safely
+- Cannot be explained by the human contributor
+
+To keep review quality high, prefer small and focused pull requests.


### PR DESCRIPTION
Fixes #41

#### Describe the changes you have made in this PR -
- Added AI-assisted contribution policy section to `CONTRIBUTING.md`
- Added a pull request template to `.github/PULL_REQUEST_TEMPLATE.md`

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, I used AI assistance

**If you used AI assistance, briefly describe:**
- Tool(s) used: Claude
- Parts of the contribution that were AI-assisted: drafting the policy wording
- How you reviewed the output: reviewed against the maintainer's suggested policy in the issue
- Tests or checks I ran: N/A

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of the documentation I added
- [x] I can explain the purpose of every documentation and logic block I added