### PR TITLE
Add MCP runtime config foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ dependencies = ["PyYAML>=6.0.0"]
 dev = ["pytest>=7"]
 openai-agents = ["openai-agents"]
 langchain = ["langchain", "langgraph"]
-mcp = []
-adapters = ["openai-agents", "langchain", "langgraph"]
+mcp = ["mcp>=1.12.4,<2"]
+adapters = ["openai-agents", "langchain", "langgraph", "mcp>=1.12.4,<2"]
 
 [project.urls]
 Homepage = "https://github.com/OWASP/Agent-Security-Regression-Harness"

--- a/src/agent_harness/mcp_runtime.py
+++ b/src/agent_harness/mcp_runtime.py
@@ -1,0 +1,263 @@
+"""Runtime configuration primitives for future full MCP host execution.
+
+This module intentionally does not start MCP servers yet. It validates the
+local runtime configuration that a future host path will use, while keeping the
+MCP SDK dependency optional and lazily imported.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import importlib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agent_harness.adapters import AdapterError
+
+
+DEFAULT_MCP_TIMEOUT_SECONDS = 5.0
+SUPPORTED_MCP_TRANSPORTS = frozenset({"stdio"})
+MCP_INSTALL_HINT = (
+    "MCP adapter dependencies are not installed. "
+    'Install them with: python -m pip install '
+    '"owasp-agent-security-regression-harness[mcp]"'
+)
+
+
+@dataclass(frozen=True)
+class MCPServerConfig:
+    """Validated configuration for one MCP server connection."""
+
+    id: str
+    transport: str
+    command: str
+    args: tuple[str, ...] = ()
+    timeout_seconds: float = DEFAULT_MCP_TIMEOUT_SECONDS
+
+
+@dataclass(frozen=True)
+class MCPRuntimeConfig:
+    """Validated runtime configuration for MCP host execution."""
+
+    servers: tuple[MCPServerConfig, ...]
+
+    @property
+    def server_ids(self) -> tuple[str, ...]:
+        """Return configured server ids in declaration order."""
+        return tuple(server.id for server in self.servers)
+
+    def get_server(self, server_id: str) -> MCPServerConfig:
+        """Return one server config by id."""
+        normalized_server_id = _normalize_server_id(server_id, "MCP server id")
+
+        for server in self.servers:
+            if server.id == normalized_server_id:
+                return server
+
+        raise AdapterError(f"MCP server id is not configured: {normalized_server_id}")
+
+
+@dataclass(frozen=True)
+class MCPHostRuntime:
+    """Validated shell for the future full MCP host implementation."""
+
+    config: MCPRuntimeConfig
+
+    def ensure_dependencies(
+        self,
+        import_module: Callable[[str], Any] = importlib.import_module,
+    ) -> None:
+        """Verify that optional MCP runtime dependencies are installed."""
+        ensure_mcp_sdk_available(import_module=import_module)
+
+
+def load_mcp_runtime_config(path: str | Path) -> MCPRuntimeConfig:
+    """Load and validate an MCP runtime config YAML file."""
+    config_path = Path(path)
+
+    if not config_path.exists():
+        raise AdapterError(f"MCP runtime config file does not exist: {config_path}")
+
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise AdapterError(f"MCP runtime config contains invalid YAML: {exc}") from exc
+
+    return parse_mcp_runtime_config(data)
+
+
+def parse_mcp_runtime_config(data: Any) -> MCPRuntimeConfig:
+    """Validate parsed MCP runtime config data."""
+    if not isinstance(data, dict):
+        raise AdapterError("MCP runtime config must be a YAML mapping/object")
+
+    server_entries = _extract_server_entries(data)
+    servers: list[MCPServerConfig] = []
+    seen_server_ids: set[str] = set()
+
+    for index, entry in server_entries:
+        server = _parse_server_config(index, entry)
+
+        if server.id in seen_server_ids:
+            raise AdapterError(f"Duplicate MCP server id: {server.id}")
+
+        seen_server_ids.add(server.id)
+        servers.append(server)
+
+    if not servers:
+        raise AdapterError("MCP runtime config must define at least one server")
+
+    return MCPRuntimeConfig(servers=tuple(servers))
+
+
+def ensure_mcp_sdk_available(
+    import_module: Callable[[str], Any] = importlib.import_module,
+) -> None:
+    """Raise a clear AdapterError when the optional MCP SDK is unavailable."""
+    try:
+        import_module("mcp")
+    except ModuleNotFoundError as exc:
+        if exc.name == "mcp":
+            raise AdapterError(MCP_INSTALL_HINT) from exc
+        raise
+
+
+def _extract_server_entries(
+    data: dict[str, Any],
+) -> list[tuple[int, dict[str, Any]]]:
+    has_servers = "servers" in data
+    has_mcp_servers = "mcp_servers" in data
+
+    if has_servers and has_mcp_servers:
+        raise AdapterError(
+            "MCP runtime config must define only one of servers or mcp_servers"
+        )
+
+    if not has_servers and not has_mcp_servers:
+        raise AdapterError("MCP runtime config must define servers")
+
+    raw_servers = data["servers"] if has_servers else data["mcp_servers"]
+
+    if not isinstance(raw_servers, list):
+        raise AdapterError("MCP runtime config servers must be a list")
+
+    entries = []
+    for index, entry in enumerate(raw_servers):
+        if not isinstance(entry, dict):
+            raise AdapterError(f"MCP server entry {index} must be an object")
+        entries.append((index, entry))
+
+    return entries
+
+
+def _parse_server_config(
+    index: int,
+    entry: dict[str, Any],
+) -> MCPServerConfig:
+    label = _server_label(index)
+    server_id = _server_id_from_entry(index, entry)
+    transport = _parse_transport(label, entry)
+    command = _parse_stdio_command(label, entry, transport)
+    args = _parse_args(label, entry)
+    timeout_seconds = _parse_timeout_seconds(label, entry)
+
+    return MCPServerConfig(
+        id=server_id,
+        transport=transport,
+        command=command,
+        args=args,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _server_id_from_entry(
+    index: int,
+    entry: dict[str, Any],
+) -> str:
+    return _normalize_server_id(
+        entry.get("id"),
+        f"MCP server entry {index} id",
+    )
+
+
+def _normalize_server_id(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AdapterError(f"{field_name} must be a non-empty string")
+
+    normalized = value.strip()
+
+    if "/" in normalized:
+        raise AdapterError(f"{field_name} must not contain '/'")
+
+    return normalized
+
+
+def _parse_transport(label: str, entry: dict[str, Any]) -> str:
+    transport = entry.get("transport")
+
+    if not isinstance(transport, str) or not transport.strip():
+        raise AdapterError(f"{label} transport must be a non-empty string")
+
+    transport = transport.strip()
+
+    if transport not in SUPPORTED_MCP_TRANSPORTS:
+        supported = ", ".join(sorted(SUPPORTED_MCP_TRANSPORTS))
+        raise AdapterError(
+            f"{label} transport {transport!r} is not supported; "
+            f"supported transports: {supported}"
+        )
+
+    return transport
+
+
+def _parse_stdio_command(
+    label: str,
+    entry: dict[str, Any],
+    transport: str,
+) -> str:
+    if transport != "stdio":
+        raise AdapterError(f"{label} transport is not implemented: {transport}")
+
+    command = entry.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise AdapterError(f"{label} command must be a non-empty string")
+
+    return command.strip()
+
+
+def _parse_args(label: str, entry: dict[str, Any]) -> tuple[str, ...]:
+    args = entry.get("args", [])
+
+    if not isinstance(args, list):
+        raise AdapterError(f"{label} args must be a list")
+
+    normalized_args = []
+    for index, arg in enumerate(args):
+        if not isinstance(arg, str):
+            raise AdapterError(f"{label} args[{index}] must be a string")
+        normalized_args.append(arg)
+
+    return tuple(normalized_args)
+
+
+def _parse_timeout_seconds(label: str, entry: dict[str, Any]) -> float:
+    timeout_seconds = entry.get("timeout_seconds", DEFAULT_MCP_TIMEOUT_SECONDS)
+
+    if isinstance(timeout_seconds, bool) or not isinstance(
+        timeout_seconds,
+        (int, float),
+    ):
+        raise AdapterError(f"{label} timeout_seconds must be a number")
+
+    timeout_seconds = float(timeout_seconds)
+    if timeout_seconds <= 0:
+        raise AdapterError(f"{label} timeout_seconds must be greater than zero")
+
+    return timeout_seconds
+
+
+def _server_label(index: int) -> str:
+    return f"MCP server entry {index}"

--- a/tests/test_mcp_runtime.py
+++ b/tests/test_mcp_runtime.py
@@ -1,0 +1,253 @@
+"""Tests for MCP runtime configuration primitives."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent_harness.adapters import AdapterError
+from agent_harness.mcp_runtime import (
+    DEFAULT_MCP_TIMEOUT_SECONDS,
+    MCP_INSTALL_HINT,
+    MCPHostRuntime,
+    ensure_mcp_sdk_available,
+    load_mcp_runtime_config,
+    parse_mcp_runtime_config,
+)
+
+
+def test_load_mcp_runtime_config_accepts_valid_list_shape(tmp_path):
+    config_path = tmp_path / "mcp-runtime.yaml"
+    config_path.write_text(
+        """
+servers:
+  - id: filesystem_fixture
+    transport: stdio
+    command: python
+    args:
+      - tests/fixtures/mcp_servers/filesystem_server.py
+    timeout_seconds: 5
+""",
+        encoding="utf-8",
+    )
+
+    config = load_mcp_runtime_config(config_path)
+
+    assert config.server_ids == ("filesystem_fixture",)
+    server = config.get_server("filesystem_fixture")
+    assert server.id == "filesystem_fixture"
+    assert server.transport == "stdio"
+    assert server.command == "python"
+    assert server.args == ("tests/fixtures/mcp_servers/filesystem_server.py",)
+    assert server.timeout_seconds == 5.0
+
+
+def test_parse_mcp_runtime_config_rejects_servers_mapping_shape():
+    with pytest.raises(AdapterError, match="servers must be a list"):
+        parse_mcp_runtime_config(
+            {
+                "servers": {
+                    "filesystem_fixture": {
+                        "transport": "stdio",
+                        "command": "python",
+                    }
+                }
+            }
+        )
+
+
+def test_parse_mcp_runtime_config_accepts_mcp_servers_list_shape():
+    config = parse_mcp_runtime_config(
+        {
+            "mcp_servers": [
+                {
+                    "id": "filesystem_fixture",
+                    "transport": "stdio",
+                    "command": "python",
+                }
+            ]
+        }
+    )
+
+    assert config.server_ids == ("filesystem_fixture",)
+    assert config.get_server("filesystem_fixture").args == ()
+    assert (
+        config.get_server("filesystem_fixture").timeout_seconds
+        == DEFAULT_MCP_TIMEOUT_SECONDS
+    )
+
+
+def test_parse_mcp_runtime_config_rejects_empty_servers():
+    with pytest.raises(AdapterError, match="at least one server"):
+        parse_mcp_runtime_config({"servers": []})
+
+
+def test_parse_mcp_runtime_config_rejects_empty_server_id():
+    with pytest.raises(AdapterError, match="id must be a non-empty string"):
+        parse_mcp_runtime_config(
+            {
+                "servers": [
+                    {
+                        "id": " ",
+                        "transport": "stdio",
+                        "command": "python",
+                    }
+                ]
+            }
+        )
+
+
+def test_parse_mcp_runtime_config_rejects_server_id_with_slash():
+    with pytest.raises(AdapterError, match="must not contain '/'"):
+        parse_mcp_runtime_config(
+            {
+                "servers": [
+                    {
+                        "id": "bad/server",
+                        "transport": "stdio",
+                        "command": "python",
+                    }
+                ]
+            }
+        )
+
+
+def test_parse_mcp_runtime_config_rejects_duplicate_server_ids():
+    with pytest.raises(AdapterError, match="Duplicate MCP server id"):
+        parse_mcp_runtime_config(
+            {
+                "servers": [
+                    {
+                        "id": "filesystem_fixture",
+                        "transport": "stdio",
+                        "command": "python",
+                    },
+                    {
+                        "id": "filesystem_fixture",
+                        "transport": "stdio",
+                        "command": "python",
+                    },
+                ]
+            }
+        )
+
+
+def test_parse_mcp_runtime_config_rejects_unknown_transport():
+    with pytest.raises(AdapterError, match="transport 'streamable_http' is not supported"):
+        parse_mcp_runtime_config(
+            {
+                "servers": [
+                    {
+                        "id": "filesystem_fixture",
+                        "transport": "streamable_http",
+                        "command": "python",
+                    }
+                ]
+            }
+        )
+
+
+def test_parse_mcp_runtime_config_rejects_missing_command():
+    with pytest.raises(AdapterError, match="command must be a non-empty string"):
+        parse_mcp_runtime_config(
+            {
+                "servers": [
+                    {
+                        "id": "filesystem_fixture",
+                        "transport": "stdio",
+                    }
+                ]
+            }
+        )
+
+
+def test_parse_mcp_runtime_config_rejects_non_list_args():
+    with pytest.raises(AdapterError, match="args must be a list"):
+        parse_mcp_runtime_config(
+            {
+                "servers": [
+                    {
+                        "id": "filesystem_fixture",
+                        "transport": "stdio",
+                        "command": "python",
+                        "args": "server.py",
+                    }
+                ]
+            }
+        )
+
+
+def test_parse_mcp_runtime_config_rejects_non_string_arg():
+    with pytest.raises(AdapterError, match=r"args\[0\] must be a string"):
+        parse_mcp_runtime_config(
+            {
+                "servers": [
+                    {
+                        "id": "filesystem_fixture",
+                        "transport": "stdio",
+                        "command": "python",
+                        "args": [123],
+                    }
+                ]
+            }
+        )
+
+
+def test_parse_mcp_runtime_config_rejects_invalid_timeout():
+    with pytest.raises(AdapterError, match="timeout_seconds must be greater than zero"):
+        parse_mcp_runtime_config(
+            {
+                "servers": [
+                    {
+                        "id": "filesystem_fixture",
+                        "transport": "stdio",
+                        "command": "python",
+                        "timeout_seconds": 0,
+                    }
+                ]
+            }
+        )
+
+
+def test_ensure_mcp_sdk_available_raises_clear_install_hint_when_missing():
+    def missing_import(name):
+        raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+
+    with pytest.raises(AdapterError) as exc_info:
+        ensure_mcp_sdk_available(import_module=missing_import)
+
+    assert str(exc_info.value) == MCP_INSTALL_HINT
+
+
+def test_ensure_mcp_sdk_available_uses_lazy_import():
+    imported_names = []
+
+    def fake_import(name):
+        imported_names.append(name)
+        return SimpleNamespace()
+
+    ensure_mcp_sdk_available(import_module=fake_import)
+
+    assert imported_names == ["mcp"]
+
+
+def test_mcp_host_runtime_placeholder_checks_dependencies():
+    def missing_import(name):
+        raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+
+    config = parse_mcp_runtime_config(
+        {
+            "servers": [
+                {
+                    "id": "filesystem_fixture",
+                    "transport": "stdio",
+                    "command": "python",
+                }
+            ]
+        }
+    )
+    runtime = MCPHostRuntime(config)
+
+    with pytest.raises(AdapterError, match="MCP adapter dependencies are not installed"):
+        runtime.ensure_dependencies(import_module=missing_import)


### PR DESCRIPTION
Refs 
#96 

#### Describe the changes you have made in this PR -

This PR is the first of three planned pull requests toward resolving the MCP host/runtime support issue.

The issue asks the harness to move beyond the current MCP workflow adapter and define the first full-host MCP execution path. The complete issue includes keeping MCP dependencies optional, safely starting configured fixture servers or connecting to configured local servers, translating MCP tool calls into canonical `mcp/<server_id>/<tool_name>` trace entries, adding local fixture tests with no external services or credentials, and updating `docs/mcp-adapter-design.md` once implementation choices are made.

This PR intentionally does not complete the full issue. It prepares the configuration and dependency foundation needed for the following MCP host work while preserving the current `--mcp-target` workflow behavior.

### Why this work is split into three PRs

The full MCP host/runtime work crosses several areas of the project: runtime configuration, optional dependency management, process execution, MCP SDK integration, trace translation, fixture servers, CLI/runner wiring, and documentation.

Splitting the implementation into three PRs keeps the work easier to review, lowers regression risk, and lets reviewers validate each layer before the next one depends on it.

The planned sequence is:

1. **PR 1: Runtime configuration foundation**
   - Add validated MCP runtime configuration primitives.
   - Keep the existing MCP workflow adapter unchanged.
   - Keep MCP dependencies optional.
   - Add focused tests for config validation and dependency detection.

2. **PR 2: Minimal stdio host execution**
   - Add the first real MCP host execution path.
   - Start configured local stdio fixture servers safely.
   - Initialize MCP sessions through the optional SDK.
   - Support deterministic fixture target execution.
   - Translate observed MCP tool calls into canonical trace entries.

3. **PR 3: CLI, documentation, and final integration**
   - Add or complete user-facing CLI/runner wiring.
   - Update `docs/mcp-adapter-design.md` with the implementation choices.
   - Update adapter documentation and README status.
   - Add final end-to-end coverage for the agreed workflow.

### What this PR includes

This PR adds the MCP runtime configuration foundation.

Files changed:

- `src/agent_harness/mcp_runtime.py`
- `tests/test_mcp_runtime.py`
- `pyproject.toml`

### Runtime configuration module

This PR introduces:

- `MCPServerConfig`
- `MCPRuntimeConfig`
- `MCPHostRuntime`
- `load_mcp_runtime_config(...)`
- `parse_mcp_runtime_config(...)`
- `ensure_mcp_sdk_available(...)`

The accepted runtime config shape is intentionally list-based:

```yaml
servers:
  - id: filesystem_fixture
    transport: stdio
    command: python
    args:
      - tests/fixtures/mcp_servers/filesystem_server.py
    timeout_seconds: 5
```

The list shape is deliberate. It allows the harness to reliably detect duplicate `server_id` values before runtime execution starts. Mapping-shaped server definitions are rejected because YAML mappings can collapse duplicate keys before the harness has a chance to validate them.

### Validation decisions

This PR validates:

- `server_id` is required
- `server_id` must be non-empty
- `server_id` must not contain `/`
- duplicate `server_id` values fail
- `servers` must be a list
- empty server lists fail
- `transport` is required
- only `stdio` is supported for now
- `command` is required for `stdio`
- `args` must be a list
- every `args` entry must be a string
- `timeout_seconds` defaults to a safe value
- `timeout_seconds` must be greater than zero

These validations are intentionally conservative because this configuration will later control local process startup for MCP fixture servers.

### Dependency strategy

MCP dependencies remain optional.

The base package still does not import or require the MCP SDK. The new runtime module checks for the SDK lazily through `ensure_mcp_sdk_available(...)` and raises a clear `AdapterError` with installation guidance when the SDK is unavailable.

The `mcp` extra now installs the SDK with a bounded range:

```toml
mcp = ["mcp>=1.12.4,<2"]
```

The aggregate `adapters` extra includes the same optional MCP dependency:

```toml
adapters = ["openai-agents", "langchain", "langgraph", "mcp>=1.12.4,<2"]
```

This keeps the base install lightweight while making the MCP install hint actionable.

### What this PR intentionally does not include

This PR does not add:

- new CLI flags
- runner integration
- real MCP sessions
- stdio server startup
- MCP fixture servers
- `list_tools`
- `call_tool`
- resource support
- prompt support
- HTTP transport support
- trace format changes
- large documentation rewrites

Those items are intentionally left for the following PRs so this foundation remains small and auditable.

### Tests and checks run

- `python -m pytest tests\test_mcp_runtime.py`
- `python -m pytest tests\test_mcp_adapter.py`
- `python -m pytest`
- `python -m compileall -q src\agent_harness tests`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code or documentation ?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance

**If you used AI assistance, briefly describe:**
- Tool(s) used: ChatGPT / Codex
- Parts of the contribution that were AI-assisted:
  - MCP runtime configuration structure
  - Validation test coverage
- How you reviewed the output:
  - Reviewed the changes against the issue requirements, the existing MCP adapter behavior, and the planned three-PR implementation split.
  - Confirmed that the existing `--mcp-target` workflow remains unchanged.
  - Confirmed that MCP SDK usage remains lazy and optional.
- Tests or checks I ran:
  - `python -m pytest tests\test_mcp_runtime.py`
  - `python -m pytest tests\test_mcp_adapter.py`
  - `python -m pytest`
  - `python -m compileall -q src\agent_harness tests`

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every documentation, function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
