### PR TITLE
Normalize MCP lifecycle events

### DIFF
--- a/docs/mcp-adapter-design.md
+++ b/docs/mcp-adapter-design.md
@@ -242,6 +242,23 @@ Example resource event:
 }
 ```
 
+MVP workflow results may supply these observations through a top-level
+`mcp_events` list. The adapter normalizes the first reviewable event set:
+
+- `mcp_resource_read`: requires `server_id` and `uri`, and defaults
+  `mcp_method` to `resources/read`.
+- `mcp_prompt_get`: requires `server_id` and a prompt name from
+  `mcp_prompt_name`, `prompt_name`, `params.name`, or `name`, and defaults
+  `mcp_method` to `prompts/get`.
+- `mcp_tool_result`: requires `server_id` plus a tool name, or a canonical
+  `name` such as `mcp/filesystem_fixture/read_file`; the normalized event
+  includes `mcp_tool_name`, canonical `name`, and `mcp_method: tools/call`.
+- `mcp_policy_decision`: requires `server_id` and `decision`.
+
+For every server-scoped MCP event, the adapter adds known `trust`, `transport`,
+server identity, and protocol-version metadata from the matching `mcp_servers`
+entry when the event does not already provide it.
+
 The adapter should avoid dumping large binary payloads into traces by default.
 It may record content type, URI, byte length, hashes, short text excerpts, and a
 `content_truncated` flag. Redaction rules should be configurable before

--- a/docs/trace-format.md
+++ b/docs/trace-format.md
@@ -107,6 +107,70 @@ a canonical source-qualified tool name:
 Scenarios that deny MCP tools should use the canonical `mcp/<server_id>/<tool>`
 name in `expected.denied_tools`.
 
+### MCP lifecycle events
+
+MCP adapters should record protocol activity that affects the agent but is not a
+plain tool call in `events`. The initial normalized event set is:
+
+| Event type | Required identity | Notes |
+|---|---|---|
+| `mcp_resource_read` | `server_id`, `uri` | Records a resource returned across the MCP trust boundary. |
+| `mcp_prompt_get` | `server_id`, `mcp_prompt_name` | Records a prompt retrieved from an MCP server. |
+| `mcp_tool_result` | `server_id`, `mcp_tool_name` | Records a tool result or tool execution error. |
+| `mcp_policy_decision` | `server_id`, `decision` | Records an adapter allow/deny decision. |
+
+The adapter may also emit connection and capability events such as
+`mcp_connection_initialized`, `mcp_capabilities_negotiated`,
+`mcp_tools_discovered`, `mcp_client_request`, and `mcp_connection_closed`.
+
+MCP events should preserve the configured server identity and trust metadata.
+For tool results, `name` should use the same canonical
+`mcp/<server_id>/<tool>` format as `tool_calls`.
+
+Example MCP event trace:
+
+```json
+{
+  "events": [
+    {
+      "type": "mcp_resource_read",
+      "server_id": "filesystem_fixture",
+      "trust": "untrusted",
+      "transport": "stdio",
+      "uri": "file:///workspace/fixtures/injected.md",
+      "mime_type": "text/markdown",
+      "content_truncated": true,
+      "mcp_method": "resources/read"
+    },
+    {
+      "type": "mcp_prompt_get",
+      "server_id": "prompt_server",
+      "trust": "third_party",
+      "mcp_prompt_name": "summarize_document",
+      "mcp_method": "prompts/get"
+    },
+    {
+      "type": "mcp_tool_result",
+      "name": "mcp/filesystem_fixture/read_file",
+      "server_id": "filesystem_fixture",
+      "mcp_tool_name": "read_file",
+      "trust": "untrusted",
+      "is_error": false,
+      "content_truncated": false,
+      "mcp_method": "tools/call"
+    },
+    {
+      "type": "mcp_policy_decision",
+      "server_id": "filesystem_fixture",
+      "trust": "untrusted",
+      "method": "tools/call",
+      "decision": "deny",
+      "reason": "tool is denied by scenario policy"
+    }
+  ]
+}
+```
+
 ## Events
 
 `events` records structured runtime facts that are not plain messages or tool calls.

--- a/src/agent_harness/mcp_adapter.py
+++ b/src/agent_harness/mcp_adapter.py
@@ -19,9 +19,31 @@ from agent_harness.trace import Trace, TraceValidationError
 
 MCP_ADAPTER_ID = "mcp"
 MCP_TOOL_NAME_PREFIX = "mcp"
+MCP_RESOURCES_READ_METHOD = "resources/read"
+MCP_PROMPTS_GET_METHOD = "prompts/get"
 MCP_TOOLS_CALL_METHOD = "tools/call"
 
 MCPWorkflowTarget = Callable[[dict[str, Any]], Trace | dict[str, Any]]
+
+MCP_EVENT_TYPES = frozenset(
+    {
+        "mcp_connection_initialized",
+        "mcp_capabilities_negotiated",
+        "mcp_tools_discovered",
+        "mcp_resource_read",
+        "mcp_prompt_get",
+        "mcp_tool_result",
+        "mcp_client_request",
+        "mcp_policy_decision",
+        "mcp_connection_closed",
+    }
+)
+MCP_EVENT_DEFAULT_METHODS = {
+    "mcp_resource_read": MCP_RESOURCES_READ_METHOD,
+    "mcp_prompt_get": MCP_PROMPTS_GET_METHOD,
+    "mcp_tool_result": MCP_TOOLS_CALL_METHOD,
+}
+MCP_SERVER_SCOPED_EVENT_TYPES = MCP_EVENT_TYPES
 
 
 def build_mcp_input(scenario: Scenario) -> dict[str, Any]:
@@ -87,6 +109,118 @@ def translate_mcp_tool_call(
 
     translated.update(_source_metadata(call, registry.get(server_id, {})))
     return translated
+
+
+def normalize_mcp_event(
+    event: dict[str, Any],
+    *,
+    server_registry: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Normalize one MCP lifecycle observation into a harness trace event."""
+    if not isinstance(event, dict):
+        raise AdapterError("MCP event must be an object")
+
+    event_type = _required_string(
+        event.get("type") or event.get("mcp_event_type"),
+        "MCP event type",
+    )
+
+    if event_type not in MCP_EVENT_TYPES:
+        raise AdapterError(f"Unsupported MCP event type: {event_type}")
+
+    registry = server_registry or {}
+    params = event.get("params", {})
+    if params is None:
+        params = {}
+    if not isinstance(params, dict):
+        raise AdapterError("MCP event params must be an object when provided")
+
+    server_id = _extract_server_id(event)
+    tool_name = None
+
+    if event_type == "mcp_tool_result":
+        tool_name = _extract_tool_name(event, params)
+        if tool_name.startswith(f"{MCP_TOOL_NAME_PREFIX}/"):
+            canonical_server_id, tool_name = _split_canonical_tool_name(tool_name)
+            if server_id is None:
+                server_id = canonical_server_id
+            elif _normalize_name_part(server_id, "MCP server id") != canonical_server_id:
+                raise AdapterError(
+                    "MCP tool result canonical name does not match server_id"
+                )
+
+    if event_type in MCP_SERVER_SCOPED_EVENT_TYPES:
+        if server_id is None:
+            raise AdapterError(f"{event_type} event is missing server_id")
+        server_id = _normalize_name_part(server_id, "MCP server id")
+
+    normalized = deepcopy(event)
+    normalized["type"] = event_type
+    normalized.pop("mcp_event_type", None)
+
+    if server_id is not None:
+        normalized["server_id"] = server_id
+        normalized.pop("mcp_server_id", None)
+        _add_event_source_metadata(normalized, event, registry.get(server_id, {}))
+
+    if event_type == "mcp_resource_read":
+        normalized["uri"] = _required_string(
+            event.get("uri") or event.get("resource_uri"),
+            "MCP resource URI",
+        )
+        normalized["mcp_method"] = _optional_string(
+            event.get("mcp_method") or event.get("method"),
+            default=MCP_EVENT_DEFAULT_METHODS[event_type],
+        )
+    elif event_type == "mcp_prompt_get":
+        prompt_name = (
+            event.get("mcp_prompt_name")
+            or event.get("prompt_name")
+            or params.get("name")
+            or event.get("name")
+        )
+        normalized["mcp_prompt_name"] = _normalize_name_part(
+            prompt_name,
+            "MCP prompt name",
+        )
+        normalized["mcp_method"] = _optional_string(
+            event.get("mcp_method") or event.get("method"),
+            default=MCP_EVENT_DEFAULT_METHODS[event_type],
+        )
+    elif event_type == "mcp_tool_result":
+        assert tool_name is not None
+        tool_name = _normalize_name_part(tool_name, "MCP tool name")
+        normalized["mcp_tool_name"] = tool_name
+        normalized["name"] = canonical_mcp_tool_name(server_id, tool_name)
+        normalized["mcp_method"] = _optional_string(
+            event.get("mcp_method") or event.get("method"),
+            default=MCP_EVENT_DEFAULT_METHODS[event_type],
+        )
+    elif event_type == "mcp_policy_decision":
+        normalized["decision"] = _required_string(
+            event.get("decision"),
+            "MCP policy decision",
+        )
+
+    return normalized
+
+
+def normalize_mcp_events(
+    events: Any,
+    *,
+    server_registry: dict[str, dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Normalize MCP lifecycle observations from an MCP workflow result."""
+    if events is None:
+        return []
+
+    if not isinstance(events, list):
+        raise AdapterError("MCP workflow field mcp_events must be a list")
+
+    return [
+        normalize_mcp_event(event, server_registry=server_registry)
+        for event in events
+    ]
 
 
 def mcp_workflow_result_to_trace(
@@ -155,6 +289,12 @@ def mcp_workflow_result_to_trace(
             "id": scenario.id,
         },
     ]
+    events.extend(
+        normalize_mcp_events(
+            result.get("mcp_events", []),
+            server_registry=server_registry,
+        )
+    )
     events.extend(_normalize_events(result.get("events", [])))
 
     return _trace_from_dict(
@@ -204,6 +344,13 @@ def _optional_string(value: Any, *, default: str) -> str:
 
     if not isinstance(value, str) or not value.strip():
         raise AdapterError("MCP method must be a non-empty string")
+
+    return value.strip()
+
+
+def _required_string(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AdapterError(f"{field_name} must be a non-empty string")
 
     return value.strip()
 
@@ -313,6 +460,52 @@ def _source_metadata(
     return metadata
 
 
+def _add_event_source_metadata(
+    event: dict[str, Any],
+    raw_event: dict[str, Any],
+    registered_server: dict[str, Any],
+) -> None:
+    server = raw_event.get("server")
+    if not isinstance(server, dict):
+        server = {}
+
+    field_map = {
+        "trust": (("trust",), ("trust",)),
+        "transport": (
+            ("transport", "mcp_transport"),
+            ("transport", "mcp_transport"),
+        ),
+        "server_name": (
+            ("server_name", "mcp_server_name"),
+            ("server_name", "mcp_server_name", "name"),
+        ),
+        "server_title": (
+            ("server_title", "mcp_server_title"),
+            ("server_title", "mcp_server_title", "title"),
+        ),
+        "server_version": (
+            ("server_version", "mcp_server_version"),
+            ("server_version", "mcp_server_version", "version"),
+        ),
+        "protocol_version": (
+            ("protocol_version",),
+            ("protocol_version",),
+        ),
+    }
+
+    for output_field, (event_fields, server_fields) in field_map.items():
+        if output_field in event:
+            continue
+
+        value = (
+            _first_present(raw_event, event_fields)
+            or _first_present(server, server_fields)
+            or _first_present(registered_server, server_fields)
+        )
+        if isinstance(value, str) and value.strip():
+            event[output_field] = value.strip()
+
+
 def _first_present(
     source: dict[str, Any],
     fields: tuple[str, ...],
@@ -390,7 +583,13 @@ def _stringify_content(value: Any) -> str:
 
 
 def _is_plain_trace_result(result: dict[str, Any]) -> bool:
-    mcp_fields = {"mcp_tool_calls", "mcp_servers", "assistant_message", "final_output"}
+    mcp_fields = {
+        "mcp_tool_calls",
+        "mcp_events",
+        "mcp_servers",
+        "assistant_message",
+        "final_output",
+    }
 
     if set(result).isdisjoint(mcp_fields):
         return {"messages", "tool_calls", "events"} <= set(result)

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -11,6 +11,8 @@ from agent_harness.mcp_adapter import (
     build_mcp_input,
     canonical_mcp_tool_name,
     mcp_workflow_result_to_trace,
+    normalize_mcp_event,
+    normalize_mcp_events,
     run_mcp_target,
     translate_mcp_tool_call,
 )
@@ -197,6 +199,121 @@ def test_translate_mcp_tool_call_requires_tool_name():
         )
 
 
+def test_normalize_mcp_resource_read_event_adds_server_metadata():
+    event = normalize_mcp_event(
+        {
+            "type": "mcp_resource_read",
+            "server_id": "filesystem_fixture",
+            "uri": "file:///workspace/fixtures/injected.md",
+            "mime_type": "text/markdown",
+            "content_truncated": True,
+        },
+        server_registry={
+            "filesystem_fixture": {
+                "trust": "untrusted",
+                "transport": "stdio",
+                "server_name": "fixture-filesystem",
+            }
+        },
+    )
+
+    assert event == {
+        "type": "mcp_resource_read",
+        "server_id": "filesystem_fixture",
+        "uri": "file:///workspace/fixtures/injected.md",
+        "mime_type": "text/markdown",
+        "content_truncated": True,
+        "trust": "untrusted",
+        "transport": "stdio",
+        "server_name": "fixture-filesystem",
+        "mcp_method": "resources/read",
+    }
+
+
+def test_normalize_mcp_prompt_get_event_preserves_prompt_name():
+    event = normalize_mcp_event(
+        {
+            "type": "mcp_prompt_get",
+            "mcp_server_id": "prompt_server",
+            "name": "summarize_document",
+            "params": {"arguments": {"style": "short"}},
+            "server": {"trust": "third_party"},
+        }
+    )
+
+    assert event["type"] == "mcp_prompt_get"
+    assert event["server_id"] == "prompt_server"
+    assert "mcp_server_id" not in event
+    assert event["mcp_prompt_name"] == "summarize_document"
+    assert event["mcp_method"] == "prompts/get"
+    assert event["trust"] == "third_party"
+    assert event["params"] == {"arguments": {"style": "short"}}
+
+
+def test_normalize_mcp_tool_result_event_parses_canonical_name():
+    event = normalize_mcp_event(
+        {
+            "type": "mcp_tool_result",
+            "name": "mcp/filesystem_fixture/read_file",
+            "is_error": False,
+            "content_truncated": False,
+        },
+        server_registry={"filesystem_fixture": {"trust": "untrusted"}},
+    )
+
+    assert event == {
+        "type": "mcp_tool_result",
+        "name": "mcp/filesystem_fixture/read_file",
+        "is_error": False,
+        "content_truncated": False,
+        "server_id": "filesystem_fixture",
+        "trust": "untrusted",
+        "mcp_tool_name": "read_file",
+        "mcp_method": "tools/call",
+    }
+
+
+def test_normalize_mcp_tool_result_rejects_conflicting_canonical_server_id():
+    with pytest.raises(AdapterError, match="canonical name does not match"):
+        normalize_mcp_event(
+            {
+                "type": "mcp_tool_result",
+                "server_id": "github_prod",
+                "name": "mcp/filesystem_fixture/read_file",
+            }
+        )
+
+
+def test_normalize_mcp_policy_decision_event_requires_decision():
+    event = normalize_mcp_event(
+        {
+            "type": "mcp_policy_decision",
+            "server_id": "untrusted_retrieval",
+            "method": "sampling/createMessage",
+            "decision": "deny",
+            "reason": "sampling is disabled for this server",
+        }
+    )
+
+    assert event["server_id"] == "untrusted_retrieval"
+    assert event["method"] == "sampling/createMessage"
+    assert event["decision"] == "deny"
+    assert event["reason"] == "sampling is disabled for this server"
+
+    with pytest.raises(AdapterError, match="MCP policy decision"):
+        normalize_mcp_event(
+            {
+                "type": "mcp_policy_decision",
+                "server_id": "untrusted_retrieval",
+            }
+        )
+
+
+def test_normalize_mcp_events_rejects_non_list():
+    with pytest.raises(AdapterError, match="mcp_events must be a list"):
+        normalize_mcp_events({"type": "mcp_resource_read"})
+
+
 def test_mcp_workflow_result_to_trace_translates_mcp_tool_calls():
     scenario = make_mcp_scenario()
 
@@ -263,6 +380,84 @@ def test_mcp_workflow_result_to_trace_translates_mcp_tool_calls():
             "type": "mcp_policy_decision",
             "id": "tool_allowed",
             "server_id": "filesystem_fixture",
+        },
+    ]
+
+
+def test_mcp_workflow_result_to_trace_normalizes_mcp_events():
+    scenario = make_mcp_scenario()
+
+    trace = mcp_workflow_result_to_trace(
+        scenario,
+        {
+            "mcp_servers": [
+                {
+                    "id": "filesystem_fixture",
+                    "trust": "untrusted",
+                    "transport": "stdio",
+                }
+            ],
+            "mcp_events": [
+                {
+                    "type": "mcp_resource_read",
+                    "server_id": "filesystem_fixture",
+                    "uri": "file:///workspace/fixtures/injected.md",
+                    "mime_type": "text/markdown",
+                    "content_truncated": True,
+                },
+                {
+                    "type": "mcp_tool_result",
+                    "server_id": "filesystem_fixture",
+                    "tool_name": "read_file",
+                    "is_error": False,
+                },
+                {
+                    "type": "mcp_policy_decision",
+                    "server_id": "filesystem_fixture",
+                    "method": "tools/call",
+                    "decision": "allow",
+                },
+            ],
+        },
+    )
+
+    assert trace.events == [
+        {
+            "type": "adapter",
+            "id": "mcp",
+        },
+        {
+            "type": "scenario",
+            "id": scenario.id,
+        },
+        {
+            "type": "mcp_resource_read",
+            "server_id": "filesystem_fixture",
+            "uri": "file:///workspace/fixtures/injected.md",
+            "mime_type": "text/markdown",
+            "content_truncated": True,
+            "trust": "untrusted",
+            "transport": "stdio",
+            "mcp_method": "resources/read",
+        },
+        {
+            "type": "mcp_tool_result",
+            "server_id": "filesystem_fixture",
+            "tool_name": "read_file",
+            "is_error": False,
+            "trust": "untrusted",
+            "transport": "stdio",
+            "mcp_tool_name": "read_file",
+            "name": "mcp/filesystem_fixture/read_file",
+            "mcp_method": "tools/call",
+        },
+        {
+            "type": "mcp_policy_decision",
+            "server_id": "filesystem_fixture",
+            "method": "tools/call",
+            "decision": "allow",
+            "trust": "untrusted",
+            "transport": "stdio",
         },
     ]
 


### PR DESCRIPTION
## Summary

- adds MCP lifecycle event normalization helpers for resource reads, prompt gets, tool results, and policy decisions
- wires normalized `mcp_events` into MCP workflow trace construction while preserving existing `events` behavior
- carries server-scoped metadata such as `server_id`, `trust`, transport, server identity, protocol version, canonical MCP tool names, and policy decisions
- documents the normalized event shapes in both the MCP adapter design and trace format docs

## Validation

- `python -m pytest tests/test_mcp_adapter.py -q`
- `python -m pytest -q`
- `python -m compileall -q src/agent_harness/mcp_adapter.py`
- `git diff --check`

Closes #97.
