### PR TITLE
fix: validate trace item object shapes

### DIFF
--- a/src/agent_harness/trace.py
+++ b/src/agent_harness/trace.py
@@ -11,6 +11,13 @@ class TraceValidationError(ValueError):
     """Raised when a trace file is invalid"""
 
 
+def _validate_object_items(field_name: str, items: list[Any]) -> None:
+    """Validate that every trace list item is an object."""
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise TraceValidationError(f"{field_name}[{index}] must be an object")
+
+
 @dataclass(frozen=True)
 class Trace:
     """Execution trace captured during a scenario run."""
@@ -37,6 +44,10 @@ class Trace:
         
         if not isinstance(events, list):
             raise TraceValidationError("events must be a list")
+
+        _validate_object_items("messages", messages)
+        _validate_object_items("tool_calls", tool_calls)
+        _validate_object_items("events", events)
         
         return cls(messages=messages, tool_calls=tool_calls, events=events)    
         

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -126,6 +126,23 @@ def test_python_callable_wraps_invalid_trace_shape():
         run_python_callable_target(scenario, malformed_agent)
 
 
+def test_python_callable_wraps_invalid_trace_item_shape():
+    scenario = make_scenario(assertions=[])
+
+    def malformed_agent(payload):
+        return {
+            "messages": ["not an object"],
+            "tool_calls": [],
+            "events": [],
+        }
+
+    with pytest.raises(
+        AdapterError,
+        match=r"Python callable returned invalid trace: messages\[0\] must be an object",
+    ):
+        run_python_callable_target(scenario, malformed_agent)
+
+
 def test_load_python_callable_loads_valid_module_function(tmp_path, monkeypatch):
     module_name = write_fake_target_module(tmp_path, monkeypatch)
 

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,41 @@
+"""Tests for trace validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_harness.trace import Trace, TraceValidationError
+
+
+def test_trace_from_dict_accepts_object_items():
+    trace = Trace.from_dict(
+        {
+            "messages": [{"role": "assistant", "content": "ok"}],
+            "tool_calls": [{"name": "search", "arguments": {"q": "owasp"}}],
+            "events": [{"type": "goal", "id": "summarize_document"}],
+        }
+    )
+
+    assert trace.messages == [{"role": "assistant", "content": "ok"}]
+    assert trace.tool_calls == [{"name": "search", "arguments": {"q": "owasp"}}]
+    assert trace.events == [{"type": "goal", "id": "summarize_document"}]
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_item"),
+    [
+        ("messages", "not an object"),
+        ("tool_calls", ["not", "an", "object"]),
+        ("events", 123),
+    ],
+)
+def test_trace_from_dict_rejects_non_object_items(field_name, bad_item):
+    data = {
+        "messages": [],
+        "tool_calls": [],
+        "events": [],
+    }
+    data[field_name] = [{}, bad_item]
+
+    with pytest.raises(TraceValidationError, match=rf"{field_name}\[1\] must be an object"):
+        Trace.from_dict(data)


### PR DESCRIPTION
Fixes #86

## Summary
- Added validation that `messages`, `tool_calls`, and `events` contain only object items.
- Included field name and item index in each validation error.
- Added unit coverage for invalid trace items and adapter error wrapping.

## Tests
- `uv run --python 3.12 --extra dev pytest tests/test_trace.py tests/test_adapters.py -q`
- `uv run --python 3.12 --extra dev pytest tests/test_cli.py tests/test_live_http.py -q`
- `uv run --python 3.12 --extra dev pytest -q`
- `git diff --check`

## AI-assisted contribution disclosure
- Tool used: OpenAI Codex.
- AI-assisted parts: small validation helper and focused unit tests.
- Human review: I checked the issue requirements, reviewed the diff, verified the errors include field/index details, and ran targeted plus full pytest suites locally.

## Notes
- Existing trace fixture paths still pass through the full test suite.