### PR TITLE
feat(adapters): supports async callables in run_python_callable_target

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -710,7 +710,11 @@ agent-harness run scenario.yaml --python-target my_package:sync_agent
 
 ### Async callables
 
-The harness will automatically detect and `await` async functions.
+The harness automatically detects and runs awaitable results from agent callables.
+If the callable returns a coroutine or other awaitable, the harness will `await` it.
+This works for both `async def` functions and regular `def` functions that return an awaitable.
+
+The implementation safely handles event loops, so it's safe to call from both synchronous code and from within an already-running `asyncio` event loop.
 
 ```python
 # my_package/my_agent.py

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -683,3 +683,47 @@ Adapters translate external systems into the harness trace contract.
 Assertions evaluate traces.
 
 Results stay consistent across frameworks.
+
+## Python callable targets
+
+The harness can run a scenario against any Python function that accepts a payload dictionary and returns a `Trace` or a trace-shaped dictionary.
+
+This is the simplest way to integrate a custom agent.
+
+### Sync callables
+
+```python
+# my_package/my_agent.py
+
+def sync_agent(payload: dict) -> dict:
+    # Run agent...
+    return {
+        "messages": [],
+        "tool_calls": [],
+        "events": [],
+    }
+```
+
+```sh
+agent-harness run scenario.yaml --python-target my_package:sync_agent
+```
+
+### Async callables
+
+The harness will automatically detect and `await` async functions.
+
+```python
+# my_package/my_agent.py
+
+async def async_agent(payload: dict) -> dict:
+    # Run agent...
+    return {
+        "messages": [],
+        "tool_calls": [],
+        "events": [],
+    }
+```
+
+```sh
+agent-harness run scenario.yaml --python-target my_package:async_agent
+```

--- a/src/agent_harness/adapters.py
+++ b/src/agent_harness/adapters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import asyncio
 import importlib
 import json
 from typing import Any
@@ -135,7 +136,10 @@ def run_python_callable_target(
     payload = build_target_payload(scenario)
 
     try:
-        trace_result = agent_callable(payload)
+        if asyncio.iscoroutinefunction(agent_callable):
+            trace_result = asyncio.run(agent_callable(payload))
+        else:
+            trace_result = agent_callable(payload)
     except Exception as exc:
         raise AdapterError(f"Python callable raised an exception: {exc}") from exc
 
@@ -149,6 +153,5 @@ def run_python_callable_target(
         )
 
     return _trace_from_dict(
-        trace_result,
-        "Python callable returned invalid trace",
+        trace_result, "Python callable returned invalid trace"
     )

--- a/src/agent_harness/adapters.py
+++ b/src/agent_harness/adapters.py
@@ -8,6 +8,7 @@ import importlib
 import json
 from typing import Any
 from urllib import error, request
+import inspect
 
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace, TraceValidationError
@@ -23,6 +24,24 @@ def build_target_payload(scenario: Scenario) -> dict[str, Any]:
         "scenario_id": scenario.id,
         "input": scenario.raw["input"],
     }
+
+
+def _run_coroutine(coro):
+    """Run a coroutine safely whether or not an event loop is already running."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        # Running inside an existing event loop — use a thread to avoid blocking
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            future = pool.submit(asyncio.run, coro)
+            return future.result()
+    else:
+        return asyncio.run(coro)
 
 
 def _trace_from_dict(trace_data: dict[str, Any], error_prefix: str) -> Trace:
@@ -136,10 +155,11 @@ def run_python_callable_target(
     payload = build_target_payload(scenario)
 
     try:
-        if asyncio.iscoroutinefunction(agent_callable):
-            trace_result = asyncio.run(agent_callable(payload))
+        result = agent_callable(payload)
+        if inspect.isawaitable(result):
+            trace_result = _run_coroutine(result)
         else:
-            trace_result = agent_callable(payload)
+            trace_result = result
     except Exception as exc:
         raise AdapterError(f"Python callable raised an exception: {exc}") from exc
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -250,3 +250,45 @@ def test_python_async_callable_wraps_exception_in_adapter_error():
 
     with pytest.raises(AdapterError, match="Python callable raised an exception"):
         run_python_callable_target(scenario, broken_agent)
+
+
+def test_python_async_callable_object():
+    """A callable object with async __call__ should work."""
+    scenario = make_scenario(assertions=[])
+
+    class AsyncAgent:
+        async def __call__(self, payload):
+            return {"messages": [], "tool_calls": [], "events": []}
+
+    trace = run_python_callable_target(scenario, AsyncAgent())
+    assert isinstance(trace, Trace)
+
+
+def test_python_sync_wrapper_returning_awaitable():
+    """A sync function returning a coroutine should work."""
+    scenario = make_scenario(assertions=[])
+
+    async def _inner(payload):
+        return {"messages": [], "tool_calls": [], "events": []}
+
+    def sync_wrapper(payload):
+        return _inner(payload)
+
+    trace = run_python_callable_target(scenario, sync_wrapper)
+    assert isinstance(trace, Trace)
+
+
+def test_python_async_callable_from_running_event_loop():
+    """Calling run_python_callable_target from a running event loop should work."""
+    import asyncio
+
+    scenario = make_scenario(assertions=[])
+
+    async def fake_agent(payload):
+        return {"messages": [], "tool_calls": [], "events": []}
+
+    async def run_from_loop():
+        return run_python_callable_target(scenario, fake_agent)
+
+    trace = asyncio.run(run_from_loop())
+    assert isinstance(trace, Trace)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -183,3 +183,70 @@ def test_load_python_callable_rejects_non_callable(tmp_path, monkeypatch):
 
     with pytest.raises(AdapterError, match="is not callable"):
         load_python_callable(f"{module_name}:NON_CALLABLE")
+
+
+def test_python_async_callable_receives_target_payload():
+    scenario = make_scenario(assertions=[])
+    observed_payload = {}
+
+    async def fake_agent(payload):
+        observed_payload.update(payload)
+        return {
+            "messages": [],
+            "tool_calls": [],
+            "events": [],
+        }
+
+    trace = run_python_callable_target(scenario, fake_agent)
+
+    assert isinstance(trace, Trace)
+    assert observed_payload == {
+        "scenario_id": scenario.id,
+        "input": scenario.raw["input"],
+    }
+
+
+def test_python_async_callable_accepts_trace_return():
+    scenario = make_scenario(assertions=[])
+
+    expected_trace = Trace(
+        messages=[{"role": "assistant", "content": "ok"}],
+        tool_calls=[],
+        events=[],
+    )
+
+    async def fake_agent(payload):
+        return expected_trace
+
+    trace = run_python_callable_target(scenario, fake_agent)
+
+    assert trace is expected_trace
+
+
+def test_python_async_callable_accepts_trace_shaped_dict_return():
+    scenario = make_scenario(assertions=[])
+
+    async def fake_agent(payload):
+        return {
+            "messages": [{"role": "assistant", "content": "ok"}],
+            "tool_calls": [],
+            "events": [],
+        }
+
+    trace = run_python_callable_target(scenario, fake_agent)
+
+    assert trace.to_dict() == {
+        "messages": [{"role": "assistant", "content": "ok"}],
+        "tool_calls": [],
+        "events": [],
+    }
+
+
+def test_python_async_callable_wraps_exception_in_adapter_error():
+    scenario = make_scenario(assertions=[])
+
+    async def broken_agent(payload):
+        raise RuntimeError("boom")
+
+    with pytest.raises(AdapterError, match="Python callable raised an exception"):
+        run_python_callable_target(scenario, broken_agent)


### PR DESCRIPTION
## Summary

Closes #91. 

The Python callable adapter only supported synchronous callables.
This change adds async support by detecting awaitable results and running them
safely whether or not an event loop is already running.

## Changes

### `src/agent_harness/adapters.py`
- Added `_run_coroutine()` helper to safely run coroutines inside or
  outside a running event loop using `ThreadPoolExecutor`
- Used `inspect.isawaitable()` instead of `asyncio.iscoroutinefunction()`
  to handle async def, callable objects with `async __call__`, and sync
  wrappers returning awaitables
- Sync callables continue to work as before

### `docs/adapters.md`
- Updated async section to accurately describe the implementation
- Removed inaccurate claim about automatic detection

### `tests/test_adapters.py`
- `test_python_async_callable_receives_target_payload` — async gets correct payload
- `test_python_async_callable_accepts_trace_return` — async can return Trace objects
- `test_python_async_callable_accepts_trace_shaped_dict_return` — async can return dicts
- `test_python_async_callable_wraps_exception_in_adapter_error` — errors wrapped correctly
- `test_python_async_callable_object` — callable object with `async __call__`
- `test_python_async_callable_from_running_event_loop` — works from running event loop
- `test_python_sync_wrapper_returning_awaitable` — sync wrapper returning awaitable

## Usage

```python
# sync — works as before
def my_agent(payload): ...

# async def
async def my_agent(payload): ...

# callable object with async __call__
class MyAgent:
    async def __call__(self, payload): ...

# sync wrapper returning awaitable
def my_agent(payload):
    return async_helper(payload)
```

## Test results:

```
tests/test_adapters.py::test_python_async_callable_receives_target_payload PASSED
tests/test_adapters.py::test_python_async_callable_accepts_trace_return PASSED
tests/test_adapters.py::test_python_async_callable_accepts_trace_shaped_dict_return PASSED
tests/test_adapters.py::test_python_async_callable_wraps_exception_in_adapter_error PASSED
tests/test_adapters.py::test_python_async_callable_object PASSED
tests/test_adapters.py::test_python_async_callable_from_running_event_loop PASSED
tests/test_adapters.py::test_python_sync_wrapper_returning_awaitable PASSED
7 passed in 0.27s
```

Full suite: 179 passed in 4.25s - no regressions.

Closes #91 