### PR TITLE
docs: realign README assertions section with actual implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ The current CLI supports:
 
 Currently implemented assertions:
 
-- `no_denied_tool_call`
-- `goal_integrity`
+- `no_denied_tool_call` — denylist and optional allowlist enforcement for tool calls
+- `goal_integrity` — fail if the agent drifts from the expected goal event
+- `memory_isolation` — fail if any configured `forbidden_markers` appear anywhere in the trace (with redacted failure evidence)
+- `no_external_recipient` — fail on outbound actions to recipients or domains outside the allowlist
 
-Recognized but not fully implemented yet:
-
-- `no_secret_disclosure`
+To test whether specific known secrets leak (API keys, tokens, PII you control), configure them as `forbidden_markers` under `expected.memory_isolation` — `memory_isolation` enforces this and reports leaks without re-exposing the marker value. See [docs/assertions/memory-isolation.md](docs/assertions/memory-isolation.md).
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary

The README listed only \`no_denied_tool_call\` and \`goal_integrity\` as implemented, omitting the two assertions that have landed since (\`memory_isolation\` from #27 and \`no_external_recipient\` from #112). It also listed \`no_secret_disclosure\` as \"recognized but not fully implemented yet\" — that assertion is intentionally deferred (#24) and the practical known-secret regression case is already covered by \`memory_isolation\` with configured \`forbidden_markers\`.

This PR replaces both blocks with a current, descriptive assertions list and a short note pointing users at \`memory_isolation\` for the known-secret case, with a cross-link to its assertion doc.

## Why

The v0.1.0 milestone goal is a packaged alpha that ships truthfully — promising features that return \`not_run\` is bad signal. See #119 and the deferral rationale on #24.

## Test plan

- [x] \`python -m pytest\` — 231 passed locally (no functional changes)
- [x] Render the README on GitHub and confirm the cross-link to \`docs/assertions/memory-isolation.md\` resolves

Closes #119