### PR TITLE
chore: add issue templates, CODEOWNERS, and enable Discussions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for the OWASP Agent Security Regression Harness.
+#
+# When a PR touches a path listed here, the matching owner is automatically
+# requested for review. The last matching pattern wins.
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo.
+* @mertsatilmaz

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report a bug in the harness.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the fields
+        below so we can reproduce the issue.
+
+        If you think this is a security vulnerability rather than a bug,
+        please follow [SECURITY.md](../blob/main/SECURITY.md) instead of
+        opening a public issue.
+
+  - type: input
+    id: harness-version
+    attributes:
+      label: Harness version
+      description: Output of `agent-harness version`.
+      placeholder: "agent-harness 0.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python --version`.
+      placeholder: "Python 3.11.x"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - "pip install -e . (editable)"
+        - "pip install ."
+        - "pip install owasp-agent-security-regression-harness"
+        - Other (describe in repro steps)
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Ubuntu 22.04 / macOS 14 / Windows 11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal commands or code to reproduce the bug.
+      placeholder: |
+        1. Run `agent-harness ...`
+        2. ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: |
+        Paste any error output or unexpected result JSON here. If you include
+        a trace snippet, **redact secrets first** — the harness scans for
+        `forbidden_markers` precisely because traces routinely capture
+        sensitive content.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Logs, stack traces, related issues, etc. Optional.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussions
+    url: https://github.com/OWASP/Agent-Security-Regression-Harness/discussions
+    about: Ask questions, propose ideas, or discuss approaches before opening an issue.
+  - name: Security reports
+    url: https://github.com/OWASP/Agent-Security-Regression-Harness/blob/main/SECURITY.md
+    about: Do NOT report security vulnerabilities through public issues. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Propose a new feature or enhancement.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a feature request, please skim
+        [docs/scope.md](../blob/main/docs/scope.md) and
+        [docs/non-goals.md](../blob/main/docs/non-goals.md). The harness is
+        intentionally narrow — features that broaden it into a generic
+        evaluation platform are likely to be declined.
+
+        For new **scenarios** (not framework features), please use the
+        scenario request template instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What can't you do today, or what would be hard to do well?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: How would this feature work? CLI changes, new modules, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered, including doing nothing.
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: |
+        What's explicitly in scope for this issue, and what's out of scope
+        (e.g. handled in a separate follow-up)?
+    validations:
+      required: false
+
+  - type: input
+    id: related
+    attributes:
+      label: Related issues or PRs
+      placeholder: "#NN, #MM"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/scenario_request.yml
+++ b/.github/ISSUE_TEMPLATE/scenario_request.yml
@@ -1,0 +1,92 @@
+name: Scenario request
+description: Propose a new executable security regression scenario.
+title: "[Scenario] "
+labels: ["scenario", "good first issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        New scenarios are one of the most useful contributions. Before
+        opening, read [docs/scenario-spec.md](../blob/main/docs/scenario-spec.md)
+        for the YAML shape and naming conventions, and
+        [docs/cookbook.md](../blob/main/docs/cookbook.md) for an end-to-end
+        example.
+
+        Note: the scenario YAML lives under
+        `scenarios/<category>/<descriptive_name>_NNN.yaml` and the id matches
+        `<category>.<descriptive_name>_NNN`.
+
+  - type: textarea
+    id: failure-mode
+    attributes:
+      label: Failure mode
+      description: What agent security failure does this scenario reproduce?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Suggested category
+      options:
+        - goal_hijack
+        - prompt_injection
+        - context_injection
+        - unsafe_tool_execution
+        - unauthorized_outbound_action
+        - sensitive_data_disclosure
+        - privilege_escalation
+        - memory_isolation
+        - approval_bypass
+        - mcp_trust_boundary
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Suggested severity
+      options:
+        - low
+        - medium
+        - high
+        - critical
+    validations:
+      required: true
+
+  - type: input
+    id: owasp-mapping
+    attributes:
+      label: OWASP LLM Top 10 / Agent risk mapping
+      description: e.g. "LLM01 Prompt Injection", "LLM06 Sensitive Information Disclosure". Optional.
+      placeholder: "LLM01 / Agent-T01"
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected agent behavior under attack
+      description: |
+        What should the agent NOT do? Which tools should remain
+        denied? Which goal should it preserve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: trust-boundaries
+    attributes:
+      label: Trust boundaries involved
+      description: |
+        Which untrusted content sources, MCP servers, or context channels
+        does this attack exercise?
+    validations:
+      required: false
+
+  - type: textarea
+    id: reference
+    attributes:
+      label: Reference attack examples
+      description: Links to research, advisories, or real-world incidents. Optional.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds three issue forms under \`.github/ISSUE_TEMPLATE/\` (bug, feature, scenario) plus a \`config.yml\` that disables blank issues and routes general questions to Discussions and security reports to \`SECURITY.md\`. Adds \`.github/CODEOWNERS\` with \`@mertsatilmaz\` as the default owner.

GitHub Discussions has been enabled on the repository in a separate API call before this PR was opened — \`contact_links\` in \`config.yml\` already points at it.

## Why

Hygiene items needed before tagging v0.1.0:

- Issue templates give contributors a structured way to file bug/feature/scenario requests and keep triage manageable.
- CODEOWNERS auto-requests review and is a prerequisite for branch protection rules later.
- Enabling Discussions gives users somewhere to ask questions and discuss approaches without burning an issue slot.

## Test plan

- [x] \`python -m pytest\` — 231 passed (no code changes)
- [ ] After merge, verify \"New issue\" on GitHub now shows the three forms and the blank-issue option is hidden
- [ ] After merge, verify the Discussions link in \`config.yml\` resolves

Closes #117