### PR TITLE
docs: add CHANGELOG and wire changelog convention into contributor workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,3 +28,4 @@ Fixes #
 - [ ] I have considered potential edge cases and how my code handles them
 - [ ] If it is a core feature, I have added thorough tests
 - [ ] My code follows the project's style guidelines and conventions
+- [ ] I added an entry under `[Unreleased]` in `CHANGELOG.md` (or this PR does not need one — pure refactor, internal tests, or CI-only change)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] — Unreleased
+
+First packaged release. Consolidates the v0.0.x development series into
+a usable OWASP Incubator baseline.
+
+### Added
+
+- **CLI** (`agent-harness`) with `version`, `validate`, and `run` subcommands.
+- **Run modes** for `run`: `--dry-run`, `--trace-file`, `--live --target-url`,
+  `--python-target`, `--openai-agent`, `--mcp-target`, `--langchain-target`.
+- **Scenario format** (YAML) with JSON Schema at
+  `schemas/scenario.schema.json` and validation in
+  `src/agent_harness/scenario.py`.
+- **Result JSON output** with schema at `schemas/result.schema.json`.
+- **Trace model** covering `messages`, `tool_calls`, and `events`.
+- **Four implemented assertions**:
+  - `no_denied_tool_call` — denylist plus optional `allowed_tools` allowlist
+  - `goal_integrity` — fail on drift from the expected goal event
+  - `memory_isolation` — fail on configured `forbidden_markers` anywhere in the
+    trace, with redacted failure evidence (count, marker index, SHA-256 prefix,
+    character length) so the harness does not re-leak the secrets it catches
+  - `no_external_recipient` — fail on outbound actions to recipients or domains
+    outside the allowlist; scans `tool_calls` (top-level and `arguments`) and
+    `tool_code` event `code` / `data.code` fields
+- **Adapters**:
+  - HTTP target adapter
+  - Python callable target adapter (sync + async, including callable objects
+    with `async __call__` and sync wrappers returning awaitables)
+  - OpenAI Agents SDK adapter (MVP)
+  - LangChain / LangGraph adapter (MVP)
+  - MCP workflow adapter (deterministic, vendor-neutral)
+  - MCP stdio host runtime with full session lifecycle, output bounding,
+    server-identity preservation, and rejection of forged MCP evidence from
+    targets
+- **23 bundled scenarios** across 8 categories: `goal_hijack`,
+  `prompt_injection`, `unsafe_tool_execution`, `sensitive_data_disclosure`,
+  `privilege_escalation`, `memory_isolation`, `approval_bypass`,
+  `mcp_trust_boundary`.
+- **Demo targets** under `examples/targets/`: HTTP, vulnerable HTTP,
+  hardened HTTP, Python callable, LangChain Runnable, MCP workflow.
+- **CI workflow** (`.github/workflows/tests.yml`) with a `test` job
+  (pytest) and a `security-regression` job (trace-based harness runs with
+  result-JSON gating and artifact upload).
+- **Cookbook** at `docs/cookbook.md` with 7 runnable examples.
+- **Documentation**: `scenario-spec.md`, `trace-format.md`, `adapters.md`,
+  `architecture.md`, `scope.md`, `non-goals.md`, `mcp-adapter-design.md`,
+  `integrating-your-agent.md`, `ci-github-actions.md`, plus per-assertion
+  docs under `docs/assertions/`.
+- **Project hygiene**: `CONTRIBUTING.md` with an AI-assistance disclosure
+  policy, `SECURITY.md`, `GOVERNANCE.md`, `AGENTS.md`, issue forms under
+  `.github/ISSUE_TEMPLATE/`, `.github/CODEOWNERS`, and a PR template.
+
+### Changed
+
+- `no_denied_tool_call` semantics extended: `expected.allowed_tools`, when
+  present, acts as an allowlist for all observed tool calls in addition to
+  the existing `denied_tools` denylist behavior.
+
+### Security
+
+- `memory_isolation` failure evidence no longer echoes the raw marker value
+  it found. Evidence now reports `count=N` plus per-match
+  `marker[index](sha256=<12-char>, chars=N)` so triage stays possible without
+  re-exposing secrets in CI logs or result artifacts.
+- MCP host rejects target-supplied MCP trace evidence (host-owned
+  `mcp_servers` / `mcp_tool_calls` / `mcp_events`, canonical
+  `mcp/<server>/<tool>` tool names, and any `tool_call` carrying top-level
+  `mcp_*` metadata fields), so a target cannot forge MCP evidence.
+- MCP fixture filesystem rejects absolute paths, `..` traversal, symlinks,
+  Windows junctions and reparse points, marker-file access, directory
+  deletions, oversized reads, and non-UTF-8 reads.
+
+[Unreleased]: https://github.com/OWASP/Agent-Security-Regression-Harness/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/OWASP/Agent-Security-Regression-Harness/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,8 @@ Large, unfocused additions will be rejected. This project is intentionally narro
 2. Create a feature branch
 3. Make a small, reviewable change
 4. Add or update tests where applicable
-5. Open a pull request
+5. Update `CHANGELOG.md` under `[Unreleased]` if the change is user-visible
+6. Open a pull request
 
 Use clear branch names:
 
@@ -42,6 +43,22 @@ docs/scenario-spec
 feature/http-agent-adapter
 fix/result-json-output
 ```
+
+## Changelog
+
+This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+If your pull request makes a user-visible change — a new feature, a behavior
+change, a bug fix, a deprecation, a removal, or a security fix — add an entry
+under `## [Unreleased]` in `CHANGELOG.md` using the appropriate subsection
+(`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Pure
+refactors, internal-only test changes, and CI-only changes do not need an
+entry.
+
+Maintainers move `[Unreleased]` entries into a versioned section as part of
+the release process; see `docs/releasing.md` (added with the release
+workflow) for details.
 
 ## AI-assisted contributions
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -41,4 +41,4 @@ The project goal is to provide executable security regression tests, not a gener
 
 Early releases will use `v0.x` versioning until the CLI, scenario format, and output format are stable enough for wider usage.
 
-The first target release is `v0.0.1`, focused on a minimal runnable harness.
+The current target release is `v0.1.0`, the first packaged Incubator baseline. See [ROADMAP.md](ROADMAP.md) for milestone scope.


### PR DESCRIPTION
## Summary

Adds \`CHANGELOG.md\` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and pre-populates the \`[0.1.0]\` section with everything consolidated from the v0.0.x development series (CLI, run modes, scenario format, four assertions, full adapter family, 23 scenarios, CI workflow, cookbook, security/hardening notes).

Wires the changelog into the contributor workflow:

- New \"Changelog\" section in \`CONTRIBUTING.md\` and a numbered step in Development workflow.
- New checklist item in \`.github/PULL_REQUEST_TEMPLATE.md\`, with an explicit \"or this PR does not need one\" carve-out for pure refactors / internal tests / CI-only.

Updates \`GOVERNANCE.md\` release target from \`v0.0.1\` to \`v0.1.0\` to match the current milestone shape in \`ROADMAP.md\`.

## Why

v0.1.0 needs a CHANGELOG to ship cleanly, and the contributor workflow needs to enforce keeping it current going forward.

## Test plan

- [x] \`python -m pytest\` — 231 passed (no code changes)
- [x] Render CHANGELOG.md on GitHub and confirm structure
- [ ] After merge, verify the next PR template includes the new checkbox

Closes #115