### PR TITLE
ci: add ruff and mypy gating, plus tests.yml concurrency block

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,27 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install harness
+        run: python -m pip install -e ".[dev]"
+      - name: Ruff
+        run: ruff check src tests
+      - name: Mypy
+        run: mypy
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ruff (line-length 100, ruleset `E,F,I,UP,B`) and mypy added to dev
+  dependencies and configured in `pyproject.toml`. CI now has a `lint`
+  job that runs both, gating PRs on lint and type errors.
+- `concurrency:` block on `tests.yml` so superseded runs on the same
+  ref cancel automatically.
+
+### Changed
+
+- Whitespace and import-order cleanup driven by ruff across `src/` and
+  `tests/`. Behaviour unchanged.
+
+### Fixed
+
+- Type errors surfaced by mypy in `mcp_adapter.py` (missing
+  `server_id is not None` guard) and `mcp_host.py` (event-dict
+  inference); both were latent invariants the runtime relied on.
+
 ## [0.1.0] — Unreleased
 
 First packaged release. Consolidates the v0.0.x development series into

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = ["PyYAML>=6.0.0"]
 
 [project.optional-dependencies]
-dev = ["pytest>=7"]
+dev = ["pytest>=7", "ruff>=0.6", "mypy>=1.10"]
 openai-agents = ["openai-agents"]
 langchain = ["langchain", "langgraph"]
 mcp = ["mcp>=1.12.4,<2"]
@@ -58,4 +58,34 @@ agent_harness = ["py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+  "E",  # pycodestyle
+  "F",  # pyflakes
+  "I",  # isort
+  "UP", # pyupgrade
+  "B",  # flake8-bugbear
+]
+
+[tool.mypy]
+python_version = "3.11"
+files = ["src/agent_harness"]
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+# Optional adapter SDKs are imported lazily; missing stubs are expected.
+module = [
+  "agent_harness.langchain_adapter",
+  "agent_harness.mcp_adapter",
+  "agent_harness.mcp_host",
+  "agent_harness.mcp_runtime",
+  "agent_harness.openai_agents_adapter",
+]
+ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = ["PyYAML>=6.0.0"]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "ruff>=0.6", "mypy>=1.10"]
+dev = ["pytest>=7", "ruff>=0.6", "mypy>=1.10", "types-PyYAML"]
 openai-agents = ["openai-agents"]
 langchain = ["langchain", "langgraph"]
 mcp = ["mcp>=1.12.4,<2"]

--- a/src/agent_harness/adapters.py
+++ b/src/agent_harness/adapters.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import asyncio
 import importlib
+import inspect
 import json
+from collections.abc import Callable
 from typing import Any
 from urllib import error, request
-import inspect
 
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace, TraceValidationError

--- a/src/agent_harness/assertions.py
+++ b/src/agent_harness/assertions.py
@@ -11,7 +11,6 @@ from agent_harness.result import AssertionResult
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace
 
-
 GOAL_EVENT_TYPE = "goal"
 MARKER_DIGEST_LENGTH = 12
 
@@ -306,7 +305,10 @@ def evaluate_no_external_recipient(scenario: Scenario, trace: Trace) -> Assertio
         return AssertionResult(
             id="no_external_recipient",
             result="not_run",
-            evidence="scenario does not define expected.allowed_recipients or expected.allowed_domains",
+            evidence=(
+                "scenario does not define expected.allowed_recipients "
+                "or expected.allowed_domains"
+            ),
         )
 
     candidates: list[str] = []

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -19,7 +19,6 @@ from agent_harness.runner import (
 from agent_harness.scenario import ScenarioValidationError, load_scenario
 from agent_harness.trace import TraceValidationError, load_trace
 
-
 VERSION = "0.0.1"
 
 

--- a/src/agent_harness/langchain_adapter.py
+++ b/src/agent_harness/langchain_adapter.py
@@ -11,7 +11,6 @@ from agent_harness.recorder import TraceRecorder
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace
 
-
 LANGCHAIN_ADAPTER_ID = "langchain"
 LANGCHAIN_INSTALL_MESSAGE = (
     "LangChain/LangGraph adapter dependencies are not installed. "

--- a/src/agent_harness/mcp_adapter.py
+++ b/src/agent_harness/mcp_adapter.py
@@ -7,15 +7,14 @@ MCP tool calls into the harness Trace format.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from copy import deepcopy
-import json
 from typing import Any
 
 from agent_harness.adapters import AdapterError, build_target_payload
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace, TraceValidationError
-
 
 MCP_ADAPTER_ID = "mcp"
 MCP_TOOL_NAME_PREFIX = "mcp"
@@ -189,6 +188,7 @@ def normalize_mcp_event(
         )
     elif event_type == "mcp_tool_result":
         assert tool_name is not None
+        assert server_id is not None
         tool_name = _normalize_name_part(tool_name, "MCP tool name")
         normalized["mcp_tool_name"] = tool_name
         normalized["name"] = canonical_mcp_tool_name(server_id, tool_name)

--- a/src/agent_harness/mcp_host.py
+++ b/src/agent_harness/mcp_host.py
@@ -8,14 +8,14 @@ MCP tools through ``MCPHostContext`` without involving an LLM.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
-from contextlib import AsyncExitStack
-from copy import deepcopy
-from dataclasses import dataclass
 import importlib
 import inspect
 import json
 import threading
+from collections.abc import Awaitable, Callable
+from contextlib import AsyncExitStack
+from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any
 
 from agent_harness.adapters import AdapterError
@@ -31,7 +31,6 @@ from agent_harness.mcp_runtime import (
 )
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace
-
 
 MCPHostTargetResult = Trace | dict[str, Any]
 MCPHostTarget = Callable[
@@ -496,7 +495,10 @@ async def _invoke_mcp_host_target(
     if inspect.iscoroutinefunction(mcp_target):
         result = mcp_target(payload, context)
     else:
-        result = await asyncio.to_thread(mcp_target, payload, context)
+        # mcp_target may be a sync callable or a sync wrapper returning an
+        # awaitable; the post-call ``isawaitable`` check handles both. mypy
+        # cannot narrow this through to_thread, so cast away the union.
+        result = await asyncio.to_thread(mcp_target, payload, context)  # type: ignore[arg-type]
 
     if inspect.isawaitable(result):
         result = await result
@@ -527,7 +529,7 @@ def _load_mcp_sdk(
 
     stdio_server_parameters = getattr(mcp_module, "StdioServerParameters", None)
     if stdio_server_parameters is None:
-        stdio_server_parameters = getattr(stdio_module, "StdioServerParameters")
+        stdio_server_parameters = stdio_module.StdioServerParameters
 
     return _MCPSDK(
         ClientSession=client_session,
@@ -697,7 +699,7 @@ def _tools_discovered_event(
                 if isinstance(tool, dict) and "name" in tool
             ]
 
-    event = {
+    event: dict[str, Any] = {
         "type": "mcp_tools_discovered",
         "server_id": server_config.id,
         "tools": tools,
@@ -748,7 +750,7 @@ def _tool_names_from_list_tools_result(tools_result: Any) -> frozenset[str]:
             return frozenset()
         raw_tools = tools_data.get("tools", [])
 
-    if not isinstance(raw_tools, (list, tuple)):
+    if not isinstance(raw_tools, list | tuple):
         return frozenset()
 
     tool_names = []
@@ -917,7 +919,7 @@ def _object_to_jsonable(
     _depth: int = 0,
     _seen: set[int] | None = None,
 ) -> Any:
-    if value is None or isinstance(value, (int, float, bool)):
+    if value is None or isinstance(value, int | float | bool):
         return value
 
     if isinstance(value, str):
@@ -952,7 +954,7 @@ def _object_to_jsonable(
         finally:
             _seen.discard(value_id)
 
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, list | tuple):
         _seen.add(value_id)
         try:
             normalized_items = [

--- a/src/agent_harness/mcp_runtime.py
+++ b/src/agent_harness/mcp_runtime.py
@@ -7,16 +7,15 @@ MCP SDK dependency optional and lazily imported.
 
 from __future__ import annotations
 
+import importlib
 from collections.abc import Callable
 from dataclasses import dataclass
-import importlib
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 from agent_harness.adapters import AdapterError
-
 
 DEFAULT_MCP_TIMEOUT_SECONDS = 5.0
 SUPPORTED_MCP_TRANSPORTS = frozenset({"stdio"})
@@ -286,7 +285,7 @@ def _parse_timeout_seconds(label: str, entry: dict[str, Any]) -> float:
 
     if isinstance(timeout_seconds, bool) or not isinstance(
         timeout_seconds,
-        (int, float),
+        int | float,
     ):
         raise AdapterError(f"{label} timeout_seconds must be a number")
 

--- a/src/agent_harness/openai_agents_adapter.py
+++ b/src/agent_harness/openai_agents_adapter.py
@@ -10,7 +10,6 @@ from agent_harness.adapters import AdapterError, build_target_payload
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace, TraceValidationError
 
-
 OPENAI_AGENTS_INSTALL_MESSAGE = (
     "OpenAI Agents SDK adapter dependencies are not installed. "
     'Install them with: python -m pip install "'
@@ -31,7 +30,7 @@ def build_openai_agents_input(scenario: Scenario) -> str:
 def _load_default_runner() -> Any:
     """Load the OpenAI Agents SDK Runner lazily."""
     try:
-        agents_module = importlib.import_module("agents")  # type: ignore[import-not-found]
+        agents_module = importlib.import_module("agents")
     except ImportError as exc:
         raise AdapterError(OPENAI_AGENTS_INSTALL_MESSAGE) from exc
 

--- a/src/agent_harness/result.py
+++ b/src/agent_harness/result.py
@@ -8,7 +8,6 @@ from typing import Any, Literal
 
 from agent_harness.trace import Trace
 
-
 ResultStatus = Literal["pass", "fail", "error", "not_run"]
 RunMode = Literal["dry_run", "trace", "live"]
 

--- a/src/agent_harness/scenario.py
+++ b/src/agent_harness/scenario.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import yaml
 
-
 VALID_CATEGORIES = {
     "goal_hijack",
     "prompt_injection",
@@ -148,7 +147,8 @@ def validate_scenario_data(data: Any) -> Scenario:
                 )
             if not all(isinstance(m, str) and m for m in markers):
                 raise ScenarioValidationError(
-                    "all items in expected.memory_isolation.forbidden_markers must be non-empty strings"
+                    "all items in expected.memory_isolation.forbidden_markers "
+                    "must be non-empty strings"
                 )
         if assertion_type == "goal_integrity":
             expected_goal = assertion.get("expected_goal")

--- a/src/agent_harness/trace.py
+++ b/src/agent_harness/trace.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
+
 
 class TraceValidationError(ValueError):
     """Raised when a trace file is invalid"""
@@ -27,7 +28,7 @@ class Trace:
     events: list[dict[str, Any]] = field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, data: Any) -> "Trace": 
+    def from_dict(cls, data: Any) -> Trace: 
         """Create a trace from parsed JSON data."""
         if not isinstance(data, dict):
             raise TraceValidationError("trace must be a JSON object")

--- a/tests/fixtures/mcp_servers/filesystem_server.py
+++ b/tests/fixtures/mcp_servers/filesystem_server.py
@@ -7,12 +7,11 @@ SDK is imported only when ``create_server`` or ``main`` is called.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 import os
-from pathlib import Path
 import stat
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
-
 
 ROOT_ENV_VAR = "MCP_FILESYSTEM_ROOT"
 ROOT_MARKER_FILE = ".mcp_fixture_root"

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from test_assertions import make_scenario
 
 from agent_harness.adapters import (
     AdapterError,
@@ -10,7 +11,6 @@ from agent_harness.adapters import (
     run_python_callable_target,
 )
 from agent_harness.trace import Trace
-from test_assertions import make_scenario
 
 
 def write_fake_target_module(tmp_path, monkeypatch) -> str:

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -10,13 +10,15 @@ from agent_harness.assertions import (
     evaluate_goal_integrity,
     evaluate_memory_isolation,
     evaluate_no_denied_tool_call,
-    evaluate_no_external_recipient,
 )
 from agent_harness.scenario import Scenario
 from agent_harness.trace import Trace
 
 
-def make_scenario(assertions: list[dict[str, Any]], expected: dict[str, Any] | None = None) -> Scenario:
+def make_scenario(
+    assertions: list[dict[str, Any]],
+    expected: dict[str, Any] | None = None,
+) -> Scenario:
     """Build a minimal valid Scenario directly with the given assertions."""
     raw: dict[str, Any] = {
         "id": "goal_hijack.unit_test",
@@ -47,7 +49,12 @@ def test_memory_isolation_passes_with_clean_trace():
         }
     }
     scenario = make_scenario([assertion], expected)
-    trace = Trace(events=[{"type": "response", "data": {"messages": [{"role": "assistant", "content": "Hello there!"}]}}])
+    trace = Trace(events=[
+        {
+            "type": "response",
+            "data": {"messages": [{"role": "assistant", "content": "Hello there!"}]},
+        }
+    ])
 
     result = evaluate_memory_isolation(scenario, trace)
 
@@ -65,7 +72,12 @@ def test_memory_isolation_fails_with_marker_in_messages():
         }
     }
     scenario = make_scenario([assertion], expected)
-    trace = Trace(events=[{"type": "response", "data": {"messages": [{"role": "assistant", "content": "The secret_key is 123."}]}}])
+    trace = Trace(events=[
+        {
+            "type": "response",
+            "data": {"messages": [{"role": "assistant", "content": "The secret_key is 123."}]},
+        }
+    ])
 
     result = evaluate_memory_isolation(scenario, trace)
 
@@ -126,7 +138,16 @@ def test_memory_isolation_reports_multiple_leaked_markers():
         }
     }
     scenario = make_scenario([assertion], expected)
-    trace = Trace(events=[{"type": "response", "data": {"messages": [{"role": "assistant", "content": "secret_key and user_password"}]}}])
+    trace = Trace(events=[
+        {
+            "type": "response",
+            "data": {
+                "messages": [
+                    {"role": "assistant", "content": "secret_key and user_password"}
+                ]
+            },
+        }
+    ])
 
     result = evaluate_memory_isolation(scenario, trace)
 
@@ -195,7 +216,16 @@ def test_memory_isolation_skips_non_string_markers():
         }
     }
     scenario = make_scenario([assertion], expected)
-    trace = Trace(events=[{"type": "response", "data": {"messages": [{"role": "assistant", "content": "no classified info here"}]}}])
+    trace = Trace(events=[
+        {
+            "type": "response",
+            "data": {
+                "messages": [
+                    {"role": "assistant", "content": "no classified info here"}
+                ]
+            },
+        }
+    ])
 
     result = evaluate_memory_isolation(scenario, trace)
 
@@ -395,7 +425,9 @@ def test_no_external_recipient_fail_with_unauthorized_recipient():
     assertion = {"type": "no_external_recipient"}
     expected = {"allowed_recipients": ["user@example.com"]}
     scenario = make_scenario([assertion], expected)
-    trace = Trace(events=[{"type": "tool_code", "code": "send_email(to='attacker@bad-domain.com')"}])
+    trace = Trace(events=[
+        {"type": "tool_code", "code": "send_email(to='attacker@bad-domain.com')"}
+    ])
 
     results = evaluate_assertions(scenario, trace)
     assert results[0].id == "no_external_recipient"
@@ -407,7 +439,9 @@ def test_no_external_recipient_fail_with_unauthorized_domain():
     assertion = {"type": "no_external_recipient"}
     expected = {"allowed_domains": ["example.com"]}
     scenario = make_scenario([assertion], expected)
-    trace = Trace(events=[{"type": "tool_code", "code": "send_email(to='user@another-domain.com')"}])
+    trace = Trace(events=[
+        {"type": "tool_code", "code": "send_email(to='user@another-domain.com')"}
+    ])
 
     results = evaluate_assertions(scenario, trace)
     assert results[0].id == "no_external_recipient"
@@ -430,7 +464,9 @@ def test_no_external_recipient_fail_with_unauthorized_recipient_in_arguments():
     assertion = {"type": "no_external_recipient"}
     expected = {"allowed_recipients": ["user@example.com"]}
     scenario = make_scenario([assertion], expected)
-    trace = Trace(tool_calls=[{"name": "send_email", "arguments": {"to": "attacker@bad-domain.com"}}])
+    trace = Trace(tool_calls=[
+        {"name": "send_email", "arguments": {"to": "attacker@bad-domain.com"}}
+    ])
 
     results = evaluate_assertions(scenario, trace)
     assert results[0].id == "no_external_recipient"
@@ -453,7 +489,9 @@ def test_no_external_recipient_fail_with_marker_in_event_data_code():
     assertion = {"type": "no_external_recipient"}
     expected = {"allowed_recipients": ["user@example.com"]}
     scenario = make_scenario([assertion], expected)
-    trace = Trace(events=[{"type": "tool_code", "data": {"code": "send_email(to='attacker@bad-domain.com')"}}])
+    trace = Trace(events=[
+        {"type": "tool_code", "data": {"code": "send_email(to='attacker@bad-domain.com')"}}
+    ])
 
     results = evaluate_assertions(scenario, trace)
     assert results[0].id == "no_external_recipient"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,6 @@ import sys
 
 from agent_harness.cli import VERSION, main
 
-
 VALID_SCENARIO = """
 id: goal_hijack.basic_001
 title: Goal hijack through untrusted retrieved content

--- a/tests/test_demo_targets.py
+++ b/tests/test_demo_targets.py
@@ -12,7 +12,6 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_langchain_adapter.py
+++ b/tests/test_langchain_adapter.py
@@ -7,8 +7,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from agent_harness.adapters import AdapterError
 import agent_harness.langchain_adapter as langchain_adapter
+from agent_harness.adapters import AdapterError
 from agent_harness.langchain_adapter import (
     build_langchain_input,
     extract_langchain_tool_calls,

--- a/tests/test_live_http.py
+++ b/tests/test_live_http.py
@@ -13,7 +13,6 @@ import pytest
 
 from agent_harness.cli import main
 
-
 LIVE_HTTP_SCENARIO = """
 id: prompt_injection.live_http_success_001
 title: Live HTTP adapter success path

--- a/tests/test_mcp_host.py
+++ b/tests/test_mcp_host.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from agent_harness.adapters import AdapterError
 from agent_harness import mcp_host
+from agent_harness.adapters import AdapterError
 from agent_harness.mcp_adapter import canonical_mcp_tool_name
 from agent_harness.mcp_host import (
     async_run_mcp_host_target,
@@ -20,7 +20,6 @@ from agent_harness.mcp_host import (
 )
 from agent_harness.mcp_runtime import MCP_INSTALL_HINT, parse_mcp_runtime_config
 from agent_harness.scenario import validate_scenario_data
-
 
 CANONICAL_DELETE_FILE_TOOL = canonical_mcp_tool_name(
     "filesystem_fixture",

--- a/tests/test_openai_agents_adapter.py
+++ b/tests/test_openai_agents_adapter.py
@@ -7,8 +7,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from agent_harness.adapters import AdapterError
 import agent_harness.openai_agents_adapter as openai_agents_adapter
+from agent_harness.adapters import AdapterError
 from agent_harness.openai_agents_adapter import (
     build_openai_agents_input,
     run_openai_agents_target,


### PR DESCRIPTION
## Summary

Adds CI signal for lint and type errors and a concurrency block to cancel superseded runs.

**Ruff** — line-length 100, ruleset \`E,F,I,UP,B\`, runs in a new \`lint\` job on every PR and push.

**Mypy** — default mode (not strict yet), files = \`src/agent_harness\`, with \`warn_unused_ignores\` and \`warn_redundant_casts\` on. Optional-adapter modules (\`langchain_adapter\`, \`mcp_adapter\`, \`mcp_host\`, \`mcp_runtime\`, \`openai_agents_adapter\`) get \`ignore_missing_imports\` since their SDKs are lazily imported.

**Concurrency** — pushes to the same branch cancel previous runs.

## Code changes driven by the new gates

Auto-fixed by ruff (sort imports, remove unused imports, modernize syntax across \`src/\` and \`tests/\`).

Manually fixed for E501 (line length 100) — wrapped long error-message strings in \`scenario.py\` / \`assertions.py\`, and long \`Trace(events=[...])\` fixtures in \`test_assertions.py\`.

Manually fixed for mypy:

- \`mcp_adapter.py\` — added \`assert server_id is not None\` in the \`mcp_tool_result\` branch so \`canonical_mcp_tool_name\` receives the expected narrowed type. This was a latent invariant the runtime already relied on.
- \`mcp_host.py\` — annotated \`event: dict[str, Any]\` in \`_tools_discovered_event\` so mypy doesn't infer a narrow value type. Added a single targeted \`# type: ignore[arg-type]\` on \`asyncio.to_thread\` for the sync-target/awaitable-result path; the runtime handles it via the post-call \`isawaitable\` check and the existing PR #111 tests cover this case.
- \`openai_agents_adapter.py\` — dropped an unused \`type: ignore\` comment now that the override handles missing imports.

## What's intentionally NOT in this PR

\`ruff format\` integration. \`ruff format --check\` reports 25 files would be reformatted, all pure whitespace style. Better to land that as its own commit so the diff is easy to review and revert if needed. Tracked as a follow-up.

## Test plan

- [x] \`ruff check src tests\` — clean
- [x] \`mypy\` — clean (14 source files checked)
- [x] \`python -m pytest -q\` — 231 passed
- [ ] After merge, CI \`lint\` job passes on main

Closes #118