### PR TITLE
feat(cli): add --exit-on-fail flag for CI gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `agent-harness run --exit-on-fail` exits with code 1 if the overall
+  result is `fail` or `error`. Default behaviour (exit 0 on every
+  successful run regardless of assertion outcomes) is unchanged.
 - Ruff (line-length 100, ruleset `E,F,I,UP,B`) and mypy added to dev
   dependencies and configured in `pyproject.toml`. CI now has a `lint`
   job that runs both, gating PRs on lint and type errors.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,23 @@ actually committed to. The vulnerable agent drifts to
 `send_email` under attack and fails the assertion; the hardened
 agent stays on `summarize_document` and passes it.
 
-### 7. Write result JSON to a file
+### 7. Fail the process on regression detection
+
+By default `agent-harness run` exits 0 on every successful run, regardless of
+assertion outcomes — the result JSON tells you what happened. To make the
+process itself fail when an assertion fails (typical CI gate), pass
+`--exit-on-fail`:
+
+```bash
+agent-harness run scenarios/goal_hijack/basic.yaml \
+  --trace-file examples/traces/denied_tool_call.json \
+  --exit-on-fail
+```
+
+The process exits with code 1 if the overall result is `fail` or `error`.
+A `pass` or `not_run` result still exits 0.
+
+### 8. Write result JSON to a file
 
 All run modes support `--out`:
 

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -26,16 +26,33 @@ The `security-regression` job in `.github/workflows/tests.yml`:
 `--out`. The `result` field in that JSON will be `pass`, `fail`, `not_run`,
 or `error`.
 
-The workflow handles this by adding an explicit result-checking step after
-all harness run steps. It reads every JSON file in `results/`,
-looks for `"result": "fail"` or `"result": "error"`, and calls `sys.exit(1)`
-if any are found. That is what actually fails the job.
+By default `agent-harness run` exits 0 on every successful run regardless of
+assertion outcomes — the result JSON is the source of truth. There are two
+ways to turn that into a job failure:
+
+**Per-step gating with `--exit-on-fail`** (simplest for a small number of
+scenarios). Pass the flag and the process exits 1 when the overall result is
+`fail` or `error`:
+
+```bash
+agent-harness run scenarios/goal_hijack/basic.yaml \
+  --trace-file examples/traces/no_denied_tool_call.json \
+  --exit-on-fail
+```
+
+**Whole-suite gating** (used by this repository's committed workflow). Run
+every scenario without `--exit-on-fail`, write each result to `results/`, and
+add a final step that scans every JSON for `"result": "fail"` or
+`"result": "error"` and exits 1 if any is found. This is what the
+`security-regression` job does today; it allows a "regression demo" step
+(where a fail is expected) to live alongside passing steps by writing that
+result to a separate directory the scanner skips.
 
 A result of `"error"` means the harness did not complete the regression check
-correctly, so the workflow treats it as a CI failure.
+correctly, so both approaches treat it as a CI failure.
 
 ```
-harness writes JSON → result-checking step reads JSON → step exits 1 → job fails
+harness writes JSON → gate (flag or post-scan) decides exit code → job pass/fail
 ```
 
 ## A note on `not_run`

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -114,6 +114,16 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         help="Optional max_turns value passed to the OpenAI Agents SDK runner.",
     )
+    run_parser.add_argument(
+        "--exit-on-fail",
+        action="store_true",
+        help=(
+            "Exit with code 1 if the overall result is 'fail' or 'error'. "
+            "Useful for gating CI on assertion failures. Without this flag, "
+            "'agent-harness run' always exits 0 on successful runs regardless "
+            "of assertion outcomes."
+        ),
+    )
 
     return parser
 
@@ -245,6 +255,9 @@ def main() -> int:
             Path(args.out).write_text(result_json + "\n", encoding="utf-8")
         else:
             print(result_json)
+
+        if args.exit_on_fail and result.result in {"fail", "error"}:
+            return 1
 
         return 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,6 +229,133 @@ def test_run_trace_file_passes_denied_tool_call_when_no_denied_tool_is_observed(
     assert result["assertions"][0]["evidence"] == "no denied tool calls observed"
 
 
+def _write_failing_trace_files(tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    trace_file = tmp_path / "trace.json"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+    trace_file.write_text(
+        json.dumps(
+            {
+                "messages": [],
+                "tool_calls": [
+                    {"name": "send_email", "arguments": {"to": "attacker@example.com"}}
+                ],
+                "events": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return scenario_file, trace_file
+
+
+def _write_passing_trace_files(tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    trace_file = tmp_path / "trace.json"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+    trace_file.write_text(
+        json.dumps({"messages": [], "tool_calls": [], "events": []}),
+        encoding="utf-8",
+    )
+    return scenario_file, trace_file
+
+
+def test_run_without_exit_on_fail_returns_zero_on_failing_assertions(
+    capsys, monkeypatch, tmp_path
+):
+    """Default behaviour: a failing assertion still exits 0."""
+    scenario_file, trace_file = _write_failing_trace_files(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent-harness", "run", str(scenario_file), "--trace-file", str(trace_file)],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert result["result"] == "fail"
+
+
+def test_run_exit_on_fail_returns_one_when_result_is_fail(
+    capsys, monkeypatch, tmp_path
+):
+    scenario_file, trace_file = _write_failing_trace_files(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--trace-file",
+            str(trace_file),
+            "--exit-on-fail",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+
+    assert exit_code == 1
+    assert result["result"] == "fail"
+
+
+def test_run_exit_on_fail_returns_zero_when_result_is_pass(
+    capsys, monkeypatch, tmp_path
+):
+    scenario_file, trace_file = _write_passing_trace_files(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--trace-file",
+            str(trace_file),
+            "--exit-on-fail",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert result["result"] == "pass"
+
+
+def test_run_exit_on_fail_returns_zero_on_dry_run(capsys, monkeypatch, tmp_path):
+    """Dry-run produces 'not_run' which is not a failure."""
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--dry-run",
+            "--exit-on-fail",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert result["result"] == "not_run"
+
+
 def test_run_live_returns_adapter_error_when_target_is_unreachable(
     capsys, monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## Summary

Adds \`agent-harness run --exit-on-fail\`. When the flag is set and the overall result is \`fail\` or \`error\`, the process exits with code 1. Default behaviour (exit 0 on every successful run regardless of assertion outcomes) is preserved — existing pipelines and the trace-mode result JSON remain authoritative.

## Why

Without this flag, \`agent-harness run\` returns 0 even when an assertion fails. Real CI use either has to parse the result JSON afterwards or wrap every \`run\` step in glue. \`--exit-on-fail\` makes per-step gating a one-flag change. The whole-suite post-scan pattern in \`security-regression\` keeps working unchanged for cases where multiple scenarios share a job.

## Tests

Four new tests in \`tests/test_cli.py\` covering the meaningful cases:

| Trace result | Flag passed | Expected exit |
|---|---|---|
| fail | no | 0 (current default) |
| fail | yes | 1 |
| pass | yes | 0 |
| not_run (dry-run) | yes | 0 |

## Docs

- README §7 \"Fail the process on regression detection\" (the existing \"Write result JSON to a file\" moves to §8)
- \`docs/ci-github-actions.md\` documents the flag as per-step gating alongside the existing whole-suite post-scan pattern, and explains why this repo's own workflow keeps the post-scan pattern (the regression-demo step deliberately fails)

## Test plan

- [x] \`python -m pytest\` — 235 passed (231 + 4 new)
- [x] \`ruff check src tests\` — clean
- [x] \`mypy\` — clean
- [x] Manual: \`agent-harness run scenarios/goal_hijack/basic.yaml --trace-file examples/traces/denied_tool_call.json --exit-on-fail\` exits 1

Closes #83