### PR TITLE
test: validate emitted result JSON against result.schema.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Schema validation tests for emitted result JSON. `tests/test_result_schema.py`
+  validates `HarnessResult.to_dict()` output against `schemas/result.schema.json`
+  across every (mode × result) combination, plus negative tests that confirm
+  the schema actually rejects malformed shapes (invalid enums, extra
+  properties, missing required fields). Catches drift between the dataclass
+  and the schema in either direction. Adds `jsonschema>=4` to dev deps.
 - `agent-harness run --exit-on-fail` exits with code 1 if the overall
   result is `fail` or `error`. Default behaviour (exit 0 on every
   successful run regardless of assertion outcomes) is unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = ["PyYAML>=6.0.0"]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "ruff>=0.6", "mypy>=1.10", "types-PyYAML"]
+dev = ["pytest>=7", "ruff>=0.6", "mypy>=1.10", "types-PyYAML", "jsonschema>=4"]
 openai-agents = ["openai-agents"]
 langchain = ["langchain", "langgraph"]
 mcp = ["mcp>=1.12.4,<2"]

--- a/tests/test_result_schema.py
+++ b/tests/test_result_schema.py
@@ -1,0 +1,220 @@
+"""Validate that emitted harness result JSON matches result.schema.json.
+
+These tests are the contract enforcement between ``HarnessResult.to_dict()``
+and ``schemas/result.schema.json``. They catch schema drift in either
+direction: if the dataclass changes shape, or if someone edits the schema
+to be more permissive than the dataclass actually is.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+
+from agent_harness.result import AssertionResult, HarnessResult
+from agent_harness.trace import Trace
+
+RESULT_SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "result.schema.json"
+
+
+@pytest.fixture(scope="module")
+def result_schema() -> dict[str, Any]:
+    return json.loads(RESULT_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def validator(result_schema: dict[str, Any]) -> jsonschema.Draft202012Validator:
+    jsonschema.Draft202012Validator.check_schema(result_schema)
+    return jsonschema.Draft202012Validator(result_schema)
+
+
+# ---------------------------------------------------------------------------
+# Positive cases: every (mode, result) combination produced by the harness
+# should validate.
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_not_run_matches_schema(validator):
+    result = HarnessResult(
+        scenario_id="goal_hijack.basic_001",
+        mode="dry_run",
+        result="not_run",
+        assertions=[AssertionResult(id="no_denied_tool_call", result="not_run")],
+        trace=Trace(),
+    )
+    validator.validate(result.to_dict())
+
+
+def test_trace_pass_matches_schema(validator):
+    result = HarnessResult(
+        scenario_id="goal_hijack.basic_001",
+        mode="trace",
+        result="pass",
+        assertions=[
+            AssertionResult(
+                id="no_denied_tool_call",
+                result="pass",
+                evidence="no denied tool calls observed",
+            ),
+        ],
+        trace=Trace(messages=[{"role": "assistant", "content": "ok"}]),
+    )
+    validator.validate(result.to_dict())
+
+
+def test_trace_fail_matches_schema(validator):
+    result = HarnessResult(
+        scenario_id="goal_hijack.basic_001",
+        mode="trace",
+        result="fail",
+        assertions=[
+            AssertionResult(
+                id="no_denied_tool_call",
+                result="fail",
+                evidence="denied tool call observed: send_email",
+            ),
+        ],
+        trace=Trace(tool_calls=[{"name": "send_email"}]),
+    )
+    validator.validate(result.to_dict())
+
+
+def test_live_pass_matches_schema(validator):
+    result = HarnessResult(
+        scenario_id="goal_hijack.basic_001",
+        mode="live",
+        result="pass",
+        assertions=[
+            AssertionResult(id="goal_integrity", result="pass", evidence="ok"),
+        ],
+        trace=Trace(
+            messages=[{"role": "user", "content": "hi"}],
+            tool_calls=[],
+            events=[{"type": "goal", "id": "summarize_document"}],
+        ),
+    )
+    validator.validate(result.to_dict())
+
+
+def test_error_result_matches_schema(validator):
+    result = HarnessResult(
+        scenario_id="some.scenario",
+        mode="trace",
+        result="error",
+        assertions=[
+            AssertionResult(
+                id="unknown_type",
+                result="error",
+                evidence="unsupported assertion type: unknown_type",
+            ),
+        ],
+        trace=Trace(),
+    )
+    validator.validate(result.to_dict())
+
+
+def test_assertion_without_evidence_matches_schema(validator):
+    result = HarnessResult(
+        scenario_id="some.scenario",
+        mode="dry_run",
+        result="not_run",
+        assertions=[AssertionResult(id="no_denied_tool_call", result="not_run")],
+        trace=Trace(),
+    )
+    data = result.to_dict()
+    assert "evidence" not in data["assertions"][0]
+    validator.validate(data)
+
+
+def test_empty_assertions_list_matches_schema(validator):
+    result = HarnessResult(
+        scenario_id="some.scenario",
+        mode="dry_run",
+        result="not_run",
+        assertions=[],
+        trace=Trace(),
+    )
+    validator.validate(result.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Negative cases: the schema should actually reject malformed shapes.
+# Without these the positive tests would still pass if someone accidentally
+# loosened additionalProperties or dropped an enum.
+# ---------------------------------------------------------------------------
+
+
+def _base_valid_result() -> dict[str, Any]:
+    return {
+        "scenario_id": "x.y",
+        "mode": "trace",
+        "result": "pass",
+        "assertions": [],
+        "trace": {"messages": [], "tool_calls": [], "events": []},
+    }
+
+
+def test_schema_rejects_invalid_mode(validator):
+    invalid = _base_valid_result() | {"mode": "totally_invalid"}
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(invalid)
+
+
+def test_schema_rejects_invalid_top_level_result(validator):
+    invalid = _base_valid_result() | {"result": "maybe"}
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(invalid)
+
+
+def test_schema_rejects_invalid_assertion_result(validator):
+    invalid = _base_valid_result() | {
+        "assertions": [{"id": "x", "result": "maybe"}],
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(invalid)
+
+
+def test_schema_rejects_extra_top_level_field(validator):
+    invalid = _base_valid_result() | {"rogue_field": True}
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(invalid)
+
+
+def test_schema_rejects_extra_assertion_field(validator):
+    invalid = _base_valid_result() | {
+        "assertions": [{"id": "x", "result": "pass", "rogue": True}],
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(invalid)
+
+
+def test_schema_rejects_extra_trace_field(validator):
+    invalid = _base_valid_result() | {
+        "trace": {
+            "messages": [],
+            "tool_calls": [],
+            "events": [],
+            "rogue": True,
+        },
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(invalid)
+
+
+def test_schema_rejects_missing_top_level_field(validator):
+    invalid = _base_valid_result()
+    del invalid["scenario_id"]
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(invalid)
+
+
+def test_schema_rejects_missing_trace_field(validator):
+    invalid = _base_valid_result() | {
+        "trace": {"messages": [], "tool_calls": []},  # events missing
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(invalid)


### PR DESCRIPTION
## Summary

Adds \`tests/test_result_schema.py\` enforcing the contract between \`HarnessResult.to_dict()\` and \`schemas/result.schema.json\`.

**7 positive tests** cover every (mode × result) combination the harness can produce: \`dry_run/not_run\`, \`trace/pass\`, \`trace/fail\`, \`live/pass\`, \`trace/error\`, plus \`assertion-without-evidence\` and \`empty-assertions-list\` edge cases.

**8 negative tests** confirm the schema actually rejects bad shapes — invalid \`mode\`/\`result\` enums, extra top-level / assertion / trace properties, missing required fields. Without these, the positive tests alone would still pass if someone accidentally loosened \`additionalProperties\` or dropped an enum.

The validator uses \`Draft202012Validator\` matching the schema's declared draft, and calls \`check_schema()\` at fixture load so schema syntax errors fail loudly.

## Why this matters for v0.1.0

The result JSON shape is part of the public contract (downstream CI gates parse it). Without these tests, schema and dataclass can drift silently — particularly easy when adding a new field to \`HarnessResult\` but forgetting the schema, or vice versa.

## Dependencies

Adds \`jsonschema>=4\` to \`[project.optional-dependencies].dev\`. CI already installs \`[dev]\`, so no workflow change needed.

## Test plan

- [x] \`python -m pytest -q\` — 250 passed (235 + 15 new)
- [x] \`ruff check src tests\` — clean
- [x] \`mypy\` — clean

Closes #87