### PR TITLE
test: cross-validate scenario.schema.json with the Python validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the schema actually rejects malformed shapes (invalid enums, extra
   properties, missing required fields). Catches drift between the dataclass
   and the schema in either direction. Adds `jsonschema>=4` to dev deps.
+- Cross-validation tests between the Python scenario validator and
+  `schemas/scenario.schema.json`. `tests/test_scenario_schema_sync.py`
+  validates every bundled scenario through both validators and pins
+  the documented asymmetries: schema is stricter on top-level structure
+  (`additionalProperties: false`, required `target.adapter`) while Python
+  is stricter on assertion-specific conditional rules (per-assertion
+  required fields, list-of-non-empty-strings shapes). The decision is
+  documented in `docs/scenario-spec.md` under "Validation: schema vs
+  Python validator".
 - `agent-harness run --exit-on-fail` exits with code 1 if the overall
   result is `fail` or `error`. Default behaviour (exit 0 on every
   successful run regardless of assertion outcomes) is unchanged.

--- a/docs/scenario-spec.md
+++ b/docs/scenario-spec.md
@@ -242,6 +242,42 @@ Before opening a pull request, confirm that:
 - the scenario has been checked with at least `--dry-run`
 - the title and wording are understandable to a new contributor
 
+## Validation: schema vs Python validator
+
+Scenario validation happens in two places:
+
+- **`schemas/scenario.schema.json`** — JSON Schema (Draft 2020-12). Used by
+  editor tooling (`# yaml-language-server: $schema=...`) to give live
+  feedback and by external tools that want to validate scenarios without
+  running Python.
+- **`src/agent_harness/scenario.py::validate_scenario_data`** — the
+  Python validator the harness runs every time it loads a scenario.
+
+These two intentionally do not overlap perfectly. The Python validator is
+the source of truth at runtime. The schema is a permissive structural
+contract that does as much as JSON Schema can express comfortably.
+
+**Where the schema is stricter than Python**:
+
+- `additionalProperties: false` at the top level (catches typoed field
+  names in the editor).
+- `target.adapter` is required.
+
+**Where Python is stricter than the schema** (assertion-specific
+conditional rules JSON Schema cannot express cheaply):
+
+- `expected.allowed_tools` / `expected.denied_tools` must be lists of
+  non-empty strings.
+- When an assertion has `type: memory_isolation`, the scenario must also
+  define `expected.memory_isolation.forbidden_markers` as a non-empty
+  list of non-empty strings.
+- When an assertion has `type: goal_integrity`, that assertion entry
+  must include a non-empty `expected_goal` string.
+
+Both contracts are enforced by `tests/test_scenario_schema_sync.py`. If
+you change either side, that test will tell you whether you preserved
+the documented asymmetry or accidentally created new drift.
+
 ## Design rule
 
 Scenario files should describe security expectations without depending on one specific model, vendor, or framework.

--- a/tests/test_scenario_schema_sync.py
+++ b/tests/test_scenario_schema_sync.py
@@ -1,0 +1,247 @@
+"""Cross-check scenario.schema.json against the Python validator.
+
+The Python validator in ``src/agent_harness/scenario.py`` and the JSON
+Schema at ``schemas/scenario.schema.json`` must agree on a well-defined
+subset of scenario shapes. Where they intentionally diverge — notably
+assertion-specific conditional rules like
+``expected.memory_isolation.forbidden_markers`` or
+``goal_integrity.expected_goal`` — the Python validator is the source
+of truth, and ``docs/scenario-spec.md`` documents the asymmetry.
+
+This module enforces three contracts:
+
+1. Every bundled scenario validates against **both** validators.
+2. Generic structural errors (missing required fields, wrong enum
+   values, wrong field types) are rejected by **both** validators.
+3. Assertion-specific conditional errors are rejected by the Python
+   validator. The JSON schema is permissive about these by design and
+   the test simply records that.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+import yaml
+
+from agent_harness.scenario import ScenarioValidationError, validate_scenario_data
+
+REPO_ROOT = Path(__file__).parent.parent
+SCENARIO_SCHEMA_PATH = REPO_ROOT / "schemas" / "scenario.schema.json"
+SCENARIOS_DIR = REPO_ROOT / "scenarios"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    return json.loads(SCENARIO_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def validator(schema: dict[str, Any]) -> jsonschema.Draft202012Validator:
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def _bundled_scenario_paths() -> list[Path]:
+    return sorted(SCENARIOS_DIR.glob("*/*.yaml"))
+
+
+def _valid_scenario() -> dict[str, Any]:
+    """Minimal scenario both validators accept."""
+    return {
+        "id": "goal_hijack.basic_001",
+        "title": "Basic goal hijack",
+        "category": "goal_hijack",
+        "severity": "high",
+        "target": {"adapter": "http_agent", "endpoint": "/run"},
+        "input": {"user_message": "Summarize the document."},
+        "expected": {"denied_tools": ["send_email"]},
+        "assertions": [{"type": "no_denied_tool_call"}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bundled scenarios must validate against both
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "scenario_path",
+    _bundled_scenario_paths(),
+    ids=lambda p: f"{p.parent.name}/{p.name}",
+)
+def test_bundled_scenario_validates_against_both(
+    scenario_path: Path,
+    validator: jsonschema.Draft202012Validator,
+) -> None:
+    data = yaml.safe_load(scenario_path.read_text(encoding="utf-8"))
+    validate_scenario_data(data)
+    validator.validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Generic structural errors: both validators must reject
+# ---------------------------------------------------------------------------
+
+
+def _mutate(data: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    """Return ``data`` with the given overrides applied at the top level."""
+    return data | overrides
+
+
+def _without(data: dict[str, Any], key: str) -> dict[str, Any]:
+    """Return ``data`` with the given top-level key removed."""
+    new = dict(data)
+    del new[key]
+    return new
+
+
+_BOTH_REJECT_CASES = [
+    pytest.param({}, id="empty"),
+    pytest.param(_without(_valid_scenario(), "id"), id="missing-id"),
+    pytest.param(_without(_valid_scenario(), "title"), id="missing-title"),
+    pytest.param(_without(_valid_scenario(), "category"), id="missing-category"),
+    pytest.param(_without(_valid_scenario(), "severity"), id="missing-severity"),
+    pytest.param(_without(_valid_scenario(), "target"), id="missing-target"),
+    pytest.param(_without(_valid_scenario(), "input"), id="missing-input"),
+    pytest.param(_without(_valid_scenario(), "expected"), id="missing-expected"),
+    pytest.param(_without(_valid_scenario(), "assertions"), id="missing-assertions"),
+    pytest.param(_mutate(_valid_scenario(), category="not_a_real_category"), id="bad-category"),
+    pytest.param(_mutate(_valid_scenario(), severity="nuclear"), id="bad-severity"),
+    pytest.param(_mutate(_valid_scenario(), id=""), id="empty-id"),
+    pytest.param(_mutate(_valid_scenario(), title=""), id="empty-title"),
+    pytest.param(_mutate(_valid_scenario(), assertions=[]), id="empty-assertions"),
+    pytest.param(
+        _mutate(_valid_scenario(), assertions=[{"not_type": "x"}]),
+        id="assertion-missing-type",
+    ),
+    pytest.param(
+        _mutate(_valid_scenario(), assertions=[{"type": ""}]),
+        id="assertion-empty-type",
+    ),
+]
+
+
+@pytest.mark.parametrize("data", _BOTH_REJECT_CASES)
+def test_both_validators_reject(
+    data: dict[str, Any],
+    validator: jsonschema.Draft202012Validator,
+) -> None:
+    with pytest.raises(ScenarioValidationError):
+        validate_scenario_data(data)
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Assertion-specific conditional rules: Python rejects, schema is permissive.
+#
+# This is the documented asymmetry (see docs/scenario-spec.md). The schema
+# cannot easily express "if assertion.type == 'memory_isolation' then
+# expected.memory_isolation.forbidden_markers must be a non-empty list of
+# non-empty strings" without verbose if/then constructs. Python is the
+# source of truth for these rules.
+# ---------------------------------------------------------------------------
+
+
+_PYTHON_ONLY_REJECT_CASES = [
+    pytest.param(
+        _mutate(
+            _valid_scenario(),
+            assertions=[{"type": "memory_isolation"}],
+        ),
+        id="memory_isolation-missing-markers",
+    ),
+    pytest.param(
+        _mutate(
+            _valid_scenario(),
+            assertions=[{"type": "memory_isolation"}],
+            expected={"memory_isolation": {"forbidden_markers": []}},
+        ),
+        id="memory_isolation-empty-markers",
+    ),
+    pytest.param(
+        _mutate(
+            _valid_scenario(),
+            assertions=[{"type": "memory_isolation"}],
+            expected={"memory_isolation": {"forbidden_markers": [123]}},
+        ),
+        id="memory_isolation-non-string-markers",
+    ),
+    pytest.param(
+        _mutate(
+            _valid_scenario(),
+            assertions=[{"type": "goal_integrity"}],
+        ),
+        id="goal_integrity-missing-expected_goal",
+    ),
+    pytest.param(
+        _mutate(
+            _valid_scenario(),
+            assertions=[{"type": "goal_integrity", "expected_goal": ""}],
+        ),
+        id="goal_integrity-empty-expected_goal",
+    ),
+    pytest.param(
+        _mutate(
+            _valid_scenario(),
+            expected={"allowed_tools": [""]},
+            assertions=[{"type": "no_denied_tool_call"}],
+        ),
+        id="empty-allowed_tools-entry",
+    ),
+    pytest.param(
+        _mutate(
+            _valid_scenario(),
+            expected={"denied_tools": [123]},
+            assertions=[{"type": "no_denied_tool_call"}],
+        ),
+        id="non-string-denied_tools-entry",
+    ),
+]
+
+
+@pytest.mark.parametrize("data", _PYTHON_ONLY_REJECT_CASES)
+def test_python_rejects_schema_accepts(
+    data: dict[str, Any],
+    validator: jsonschema.Draft202012Validator,
+) -> None:
+    with pytest.raises(ScenarioValidationError):
+        validate_scenario_data(data)
+    # Schema is intentionally permissive here — see docs/scenario-spec.md.
+    validator.validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Schema-only rules: schema rejects, Python is permissive.
+#
+# These are cases where the JSON schema catches structural issues the Python
+# validator does not. They are documented so they don't drift silently.
+# ---------------------------------------------------------------------------
+
+
+_SCHEMA_ONLY_REJECT_CASES = [
+    pytest.param(
+        _mutate(_valid_scenario(), rogue_top_level_field="x"),
+        id="extra-top-level-field",
+    ),
+    pytest.param(
+        _mutate(_valid_scenario(), target={}),
+        id="target-missing-adapter",
+    ),
+]
+
+
+@pytest.mark.parametrize("data", _SCHEMA_ONLY_REJECT_CASES)
+def test_schema_rejects_python_accepts(
+    data: dict[str, Any],
+    validator: jsonschema.Draft202012Validator,
+) -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(data)
+    # Python is intentionally permissive here — see docs/scenario-spec.md.
+    validate_scenario_data(data)


### PR DESCRIPTION
## Summary

Adds \`tests/test_scenario_schema_sync.py\` with 45 tests that enforce three contracts between \`schemas/scenario.schema.json\` and \`src/agent_harness/scenario.py::validate_scenario_data\`:

1. **Every bundled scenario validates against both** (20 parametrized cases — every \`.yaml\` under \`scenarios/\`).
2. **Generic structural errors are rejected by both** (16 cases: missing required fields, bad enums, empty assertions, etc).
3. **Documented asymmetries are pinned, not silent**:
   - 7 cases where Python rejects but the schema accepts (assertion-specific conditional rules: \`memory_isolation\` markers, \`goal_integrity.expected_goal\`, \`allowed_tools\`/\`denied_tools\` shapes).
   - 2 cases where the schema rejects but Python accepts (extra top-level fields, \`target\` without \`adapter\`).

## Decision (per issue #88's \"decide and document\" requirement)

**The schema stays intentionally permissive about assertion-specific conditional rules.** JSON Schema can express \"if/then\" conditional shapes, but only verbosely, and every new assertion type would require a schema edit. Python is the source of truth for those rules at runtime. The schema does what JSON Schema does well: required fields, enums, top-level \`additionalProperties: false\`, required \`target.adapter\`.

Documented in \`docs/scenario-spec.md\` under a new \"Validation: schema vs Python validator\" section that names every asymmetry, so future contributors know what they're allowed to break on each side.

## Test plan

- [x] \`python -m pytest -q\` — 295 passed (250 + 45 new)
- [x] \`ruff check src tests\` — clean
- [x] \`mypy\` — clean

Closes #88