### PR TITLE
ci: add release workflow and document the release procedure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: release
+
+# Triggers on annotated version tags like `v0.1.0`. The tag must point at a
+# commit on `main` that has already passed `tests.yml`.
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify quality gates on the tagged commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install harness
+        run: python -m pip install -e ".[dev]"
+      - name: Ruff
+        run: ruff check src tests
+      - name: Mypy
+        run: mypy
+      - name: Pytest
+        run: python -m pytest
+
+  build:
+    name: Build sdist and wheel
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+      - name: Build distributions
+        run: python -m build
+      - name: Upload distributions
+        uses: actions/upload-artifact@v6
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # PyPI trusted publishing requires both the environment binding and id-token.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/owasp-agent-security-regression-harness
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v6
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Attach distributions to GitHub release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Download distributions
+        uses: actions/download-artifact@v6
+        with:
+          name: dist
+          path: dist/
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          # Body is auto-generated from PRs merged since the previous tag.
+          # CHANGELOG.md remains the canonical record.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release workflow at `.github/workflows/release.yml`. Pushing a tag
+  matching `v<major>.<minor>.<patch>` (or `…rc<N>`) runs the quality
+  gates on the tagged commit, builds sdist + wheel, publishes to PyPI
+  via trusted publishing (no long-lived token), and attaches the
+  artifacts to a GitHub release. The procedure for maintainers is
+  documented in `docs/releasing.md` (one-time PyPI setup, per-release
+  checklist, and rollback paths).
 - Per-scenario passing trace fixtures for all 20 bundled scenarios at
   `examples/traces/<category>/<scenario_basename>_pass.json`, plus
   `tests/test_scenario_pass_fixtures.py` which runs each scenario

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ refactors, internal-only test changes, and CI-only changes do not need an
 entry.
 
 Maintainers move `[Unreleased]` entries into a versioned section as part of
-the release process; see `docs/releasing.md` (added with the release
-workflow) for details.
+the release process; see [`docs/releasing.md`](docs/releasing.md) for the
+full procedure.
 
 ## AI-assisted contributions
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,93 @@
+# Releasing
+
+This document is for project maintainers. It covers how to cut a release
+of the OWASP Agent Security Regression Harness to PyPI.
+
+## One-time setup (PyPI trusted publishing)
+
+Before the first release, configure PyPI to trust this GitHub repository
+so the release workflow can publish without a long-lived token.
+
+1. Reserve the project name on PyPI by creating the project under
+   `https://pypi.org/project/owasp-agent-security-regression-harness/`
+   (or wait until the first publish creates it).
+2. On PyPI, go to **Your projects → owasp-agent-security-regression-harness
+   → Publishing → Add a new pending publisher**.
+3. Fill in:
+   - **PyPI Project Name**: `owasp-agent-security-regression-harness`
+   - **Owner**: `OWASP`
+   - **Repository name**: `Agent-Security-Regression-Harness`
+   - **Workflow name**: `release.yml`
+   - **Environment name**: `pypi`
+4. On GitHub, go to **Settings → Environments** and create an
+   environment named `pypi`. Add a required reviewer (the maintainer
+   who approves releases) so a release cannot publish without explicit
+   approval.
+
+After this is configured, the workflow at `.github/workflows/release.yml`
+can publish to PyPI via OIDC. No tokens live in the repo.
+
+## Per-release checklist
+
+For every release tag (e.g. `v0.1.0`):
+
+1. **Update the CHANGELOG.** Move entries from `[Unreleased]` into a
+   versioned section like `[0.1.0]` with today's date. Leave an empty
+   `[Unreleased]` block for the next cycle.
+2. **Bump the version**. Update the version string in:
+   - `pyproject.toml`
+   - `src/agent_harness/__init__.py` (`__version__`)
+   - `src/agent_harness/cli.py` (`VERSION`)
+   - `README.md` (the expected `agent-harness version` output)
+3. **Open a release-prep PR** with those two changes. Title it
+   `release: prepare v0.X.Y`. Merge it once CI passes.
+4. **Tag** the merge commit on `main`:
+
+   ```bash
+   git checkout main
+   git pull
+   git tag -a v0.1.0 -m "v0.1.0"
+   git push origin v0.1.0
+   ```
+
+5. **Watch the workflow.** The release workflow runs four jobs:
+   - `verify` — pytest, ruff, mypy on the tagged commit
+   - `build` — `python -m build` produces sdist + wheel artifacts
+   - `publish-pypi` — uploads to PyPI via trusted publishing (waits
+     for environment approval if you required one)
+   - `github-release` — attaches sdist + wheel to the GitHub release
+     page with auto-generated release notes
+
+6. **Verify the published artifact**:
+
+   ```bash
+   pip install --upgrade --no-cache-dir owasp-agent-security-regression-harness
+   agent-harness version
+   ```
+
+## What if a release fails?
+
+**Publish step failed before PyPI accepted the upload.** Fix the issue,
+delete the tag locally and remotely, re-tag, and re-push:
+
+```bash
+git tag -d v0.1.0
+git push origin :refs/tags/v0.1.0
+# fix the issue, commit, push
+git tag -a v0.1.0 -m "v0.1.0"
+git push origin v0.1.0
+```
+
+**Publish step succeeded but the artifact is broken.** PyPI does **not**
+allow re-uploading the same version. Bump to the next patch version
+(e.g. `v0.1.1`), update CHANGELOG, retag, and let the workflow run.
+
+**GitHub release step failed but PyPI succeeded.** Re-run the
+`github-release` job from the Actions tab. The artifacts are already
+on PyPI; this step only attaches them to the GitHub release page.
+
+## Tag format
+
+Only tags matching `v<major>.<minor>.<patch>` and
+`v<major>.<minor>.<patch>rc<N>` trigger the release workflow. Other
+tags are ignored.


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/release.yml\` and \`docs/releasing.md\`. Pushing a tag matching \`v<major>.<minor>.<patch>\` (or \`…rc<N>\`) runs four gated jobs in sequence:

1. **verify** — pytest, ruff, mypy on the tagged commit
2. **build** — \`python -m build\` produces sdist + wheel
3. **publish-pypi** — uploads to PyPI via OIDC trusted publishing (no long-lived token)
4. **github-release** — attaches sdist + wheel to the GitHub release with auto-generated notes

## One-time setup you'll need to do before the first real tag

The workflow is dormant until two things are configured:

**On PyPI** (one-time, ~3 minutes):

1. Go to https://pypi.org/manage/account/publishing/ → Add a pending publisher
2. Fill in:
   - PyPI Project Name: \`owasp-agent-security-regression-harness\`
   - Owner: \`OWASP\`
   - Repository: \`Agent-Security-Regression-Harness\`
   - Workflow: \`release.yml\`
   - Environment: \`pypi\`

**On GitHub** (one-time, ~1 minute):

1. Repo Settings → Environments → New environment named \`pypi\`
2. Add yourself as a required reviewer so a tag can't silently publish

Both steps are in \`docs/releasing.md\` so future maintainers find them too.

## Rehearsal before v0.1.0

Once those are configured, we can rehearse with a release candidate tag like \`v0.1.0rc1\` (the workflow accepts \`rcN\` suffixes). PyPI treats RC versions as pre-releases. If it works, we tag \`v0.1.0\` for the real release.

## Test plan

- [x] \`python -m pytest -q\` — 315 passed (no code changes)
- [x] \`ruff check src tests\` — clean
- [x] \`mypy\` — clean
- [x] Workflow YAML reviewed for syntax
- [ ] Trusted publishing configured on PyPI side (you)
- [ ] \`pypi\` environment configured on GitHub side (you)
- [ ] Rehearsal with \`v0.1.0rc1\` (after the version bump in #116)

Closes #114