### PR TITLE
release: bump to 0.1.0rc1 for release-workflow rehearsal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "owasp-agent-security-regression-harness"
-version = "0.1.0"
+version = "0.1.0rc1"
 description = "OWASP harness for executable security regression testing of agentic applications and MCP-integrated systems."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/agent_harness/__init__.py
+++ b/src/agent_harness/__init__.py
@@ -1,3 +1,3 @@
 """OWASP Agent Security Regression Harness."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.0rc1"

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -19,7 +19,7 @@ from agent_harness.runner import (
 from agent_harness.scenario import ScenarioValidationError, load_scenario
 from agent_harness.trace import TraceValidationError, load_trace
 
-VERSION = "0.1.0"
+VERSION = "0.1.0rc1"
 
 
 def build_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary

Quick version bump for the release-workflow rehearsal. Sets the version string in \`pyproject.toml\`, \`src/agent_harness/__init__.py\`, and \`src/agent_harness/cli.py\` to \`0.1.0rc1\`.

\`README.md\` and \`CHANGELOG.md\` are intentionally left at \`0.1.0\` — those document the final release; \`0.1.0rc1\` is just the release candidate of that same code.

## Why

The release workflow has never run in production. Tagging \`v0.1.0rc1\` first exercises the entire pipeline (build → trusted-publishing OIDC handshake → PyPI pre-release upload → GitHub release attachment) without consuming the \`0.1.0\` version slot on PyPI. PyPI does not allow re-upload of the same version, so a botched \`0.1.0\` would force us to \`0.1.1\`.

## Test plan

- [x] \`python -m pytest -q\` — 315 passed
- [x] \`agent-harness version\` prints \`agent-harness 0.1.0rc1\` locally
- [ ] After merge, tag \`v0.1.0rc1\` and watch the release workflow

## Next step after merge

Tag \`v0.1.0rc1\` on \`main\`, wait for the release workflow to hit the \`pypi\` environment gate, you approve, the pre-release lands on PyPI. After verification, a follow-up PR bumps back to \`0.1.0\` for the real tag.