### PR TITLE
release: bump to 0.1.0 final after successful rc1 rehearsal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "owasp-agent-security-regression-harness"
-version = "0.1.0rc1"
+version = "0.1.0"
 description = "OWASP harness for executable security regression testing of agentic applications and MCP-integrated systems."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/agent_harness/__init__.py
+++ b/src/agent_harness/__init__.py
@@ -1,3 +1,3 @@
 """OWASP Agent Security Regression Harness."""
 
-__version__ = "0.1.0rc1"
+__version__ = "0.1.0"

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -19,7 +19,7 @@ from agent_harness.runner import (
 from agent_harness.scenario import ScenarioValidationError, load_scenario
 from agent_harness.trace import TraceValidationError, load_trace
 
-VERSION = "0.1.0rc1"
+VERSION = "0.1.0"
 
 
 def build_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary

\`v0.1.0rc1\` published to PyPI successfully and the full release workflow ran end-to-end (verify → build → publish-pypi → github-release). The pipeline is validated. Bumps version back to \`0.1.0\` in \`pyproject.toml\`, \`__init__.py\`, and \`cli.py\` for the final tag.

## Test plan

- [x] \`python -m pytest -q\` — 315 passed
- [x] \`ruff check src tests\` — clean
- [x] \`mypy\` — clean
- [x] Editable install reports \`agent-harness 0.1.0\`

## Next step after merge

Tag \`v0.1.0\` on \`main\`. Release workflow fires, you approve the \`pypi\` environment gate, the first stable release lands on PyPI. Then we announce.