### PR TITLE
ci: add pytest-cov coverage gate at 80%

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         run: python -m pytest --cov=src/agent_harness --cov-report=html --cov-fail-under=80
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: htmlcov/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install harness
         run: python -m pip install -e ".[dev]"
       - name: Run tests
-        run: python -m pytest --cov=src/agent_harness --cov-report=html --cov-fail-under=80
+        run: python -m pytest --cov=src/agent_harness --cov-report=term-missing --cov-report=html --cov-fail-under=80
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,13 @@ jobs:
       - name: Install harness
         run: python -m pip install -e ".[dev]"
       - name: Run tests
-        run: python -m pytest
+        run: python -m pytest --cov=src/agent_harness --cov-report=html --cov-fail-under=80
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: htmlcov/
 
   security-regression:
     name: Run security regression scenarios

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ warn_redundant_casts = true
 [tool.coverage.run]
 source = ["src/agent_harness"]
 omit = [
-    "examples/*",
     "src/agent_harness/*_adapter.py",
     "src/agent_harness/mcp_*.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = ["PyYAML>=6.0.0"]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "ruff>=0.6", "mypy>=1.10", "types-PyYAML", "jsonschema>=4"]
+dev = ["pytest>=7", "pytest-cov>=7", "ruff>=0.6", "mypy>=1.10", "types-PyYAML", "jsonschema>=4"]
 openai-agents = ["openai-agents"]
 langchain = ["langchain", "langgraph"]
 mcp = ["mcp>=1.12.4,<2"]
@@ -77,6 +77,14 @@ python_version = "3.11"
 files = ["src/agent_harness"]
 warn_unused_ignores = true
 warn_redundant_casts = true
+
+[tool.coverage.run]
+source = ["src/agent_harness"]
+omit = [
+    "examples/*",
+    "src/agent_harness/*_adapter.py",
+    "src/agent_harness/mcp_*.py",
+]
 
 [[tool.mypy.overrides]]
 # Optional adapter SDKs are imported lazily; missing stubs are expected.


### PR DESCRIPTION
Fixes #120

#### Describe the changes you have made in this PR -
Added a CI coverage gate for the core package using pytest-cov.

- Added `pytest-cov>=7` to dev dependencies
- Configured `[tool.coverage.run]` with omit patterns for adapters and examples
- Updated `tests.yml` to run pytest with `--cov-fail-under=80`
- Added coverage HTML report upload as CI artifact

---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code or documentation ?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance

**If you used AI assistance, briefly describe:**
- Tool(s) used: Claude
- Parts of the contribution that were AI-assisted: Understanding the issue requirements, understanding pyproject.toml configuration structure
- How you reviewed the output: Read and understood every line before applying, ran tests locally and verified 93% coverage output
- Tests or checks I ran: `pytest --cov=src/agent_harness --cov-report=term-missing --cov-fail-under=80` locally, passed at 93%

---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every documentation, function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
- [x] I added an entry under `[Unreleased]` in `CHANGELOG.md` (or this PR does not need one — pure refactor, internal tests, or CI-only change)