### PR TITLE
Added a custom http timeout.

### DIFF
--- a/src/agent_harness/adapters.py
+++ b/src/agent_harness/adapters.py
@@ -94,7 +94,7 @@ def load_python_callable(
     return target
 
 
-def run_http_target(scenario: Scenario, target_url: str) -> Trace:
+def run_http_target(scenario: Scenario, target_url: str, timeout: int = 30) -> Trace:
     """Run a scenario against an HTTP target and return its trace."""
     body = build_target_payload(scenario)
     request_data = json.dumps(body).encode("utf-8")
@@ -109,12 +109,15 @@ def run_http_target(scenario: Scenario, target_url: str) -> Trace:
     )
 
     try:
-        with request.urlopen(http_request, timeout=30) as response:
+        with request.urlopen(http_request, timeout=timeout) as response:
             response_text = response.read().decode("utf-8")
     except error.URLError as exc:
+        if isinstance(exc.reason, TimeoutError) or "timed out" in str(exc.reason):
+             raise AdapterError(f"HTTP target request timed out after {timeout} seconds") from exc
         raise AdapterError(f"HTTP target request failed: {exc}") from exc
 
     try:
+        # DON'T FORGET THIS LINE:
         trace_data = json.loads(response_text)
     except json.JSONDecodeError as exc:
         raise AdapterError(f"HTTP target returned invalid JSON: {exc}") from exc

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -77,7 +77,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--target-url",
         help="HTTP URL for the live target.",
     )
-    # 1. ADDED ARGUMENT HERE
     run_parser.add_argument(
         "--target-timeout",
         type=int,
@@ -120,12 +119,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--openai-agent-max-turns",
         type=int,
         help="Optional max_turns value passed to the OpenAI Agents SDK runner.",
-    )
-    run_parser.add_argument(
-        "--target-timeout",
-        type=int,
-        default=30,  # or whatever your default timeout should be
-        help="Timeout for live target requests in seconds",
     )
     run_parser.add_argument(
         "--exit-on-fail",
@@ -183,7 +176,6 @@ def main() -> int:
         if args.target_url and not args.live:
             parser.error("--target-url can only be used with --live")
 
-        # 2. ADDED VALIDATION HERE
         if args.target_timeout is not None and args.target_timeout <= 0:
             parser.error("--target-timeout must be greater than zero")
 
@@ -216,7 +208,6 @@ def main() -> int:
         elif args.live:
             try:
                 assert args.target_url is not None
-                # 3. PASSED TIMEOUT TO THE RUNNER HERE
                 result = run_scenario_live(scenario, args.target_url, timeout=args.target_timeout)
             except AdapterError as exc:
                 print(f"adapter error: {exc}", file=sys.stderr)

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -77,6 +77,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--target-url",
         help="HTTP URL for the live target.",
     )
+    # 1. ADDED ARGUMENT HERE
+    run_parser.add_argument(
+        "--target-timeout",
+        type=int,
+        default=30,
+        help="Timeout in seconds for live HTTP target requests (default: 30).",
+    )
     run_parser.add_argument(
         "--python-target",
         help=(
@@ -113,6 +120,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--openai-agent-max-turns",
         type=int,
         help="Optional max_turns value passed to the OpenAI Agents SDK runner.",
+    )
+    run_parser.add_argument(
+        "--target-timeout",
+        type=int,
+        default=30,  # or whatever your default timeout should be
+        help="Timeout for live target requests in seconds",
     )
     run_parser.add_argument(
         "--exit-on-fail",
@@ -170,6 +183,10 @@ def main() -> int:
         if args.target_url and not args.live:
             parser.error("--target-url can only be used with --live")
 
+        # 2. ADDED VALIDATION HERE
+        if args.target_timeout is not None and args.target_timeout <= 0:
+            parser.error("--target-timeout must be greater than zero")
+
         if args.openai_agent_max_turns is not None and args.openai_agent is None:
             parser.error("--openai-agent-max-turns can only be used with --openai-agent")
 
@@ -199,7 +216,8 @@ def main() -> int:
         elif args.live:
             try:
                 assert args.target_url is not None
-                result = run_scenario_live(scenario, args.target_url)
+                # 3. PASSED TIMEOUT TO THE RUNNER HERE
+                result = run_scenario_live(scenario, args.target_url, timeout=args.target_timeout)
             except AdapterError as exc:
                 print(f"adapter error: {exc}", file=sys.stderr)
                 return 1

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -115,6 +115,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         help="Optional max_turns value passed to the OpenAI Agents SDK runner.",
     )
+    run_parser.add_argument(
+        "--target-timeout",
+        type=int,
+        default=30,
+        help="Timeout in seconds for HTTP requests (default: 30)"
+    )
 
     return parser
 
@@ -167,6 +173,13 @@ def main() -> int:
         if args.langchain_goal_event is not None and args.langchain_target is None:
             parser.error("--langchain-goal-event can only be used with --langchain-target")
 
+        #Timer compute
+        if args.target_timeout <= 0:
+            parser.error("--target-timeout must be greater than zero")
+
+        if args.target_timeout != 30 and not args.live:
+            parser.error("--target-timeout can only be used with --live")
+
         if (
             args.langchain_goal_event is not None
             and not args.langchain_goal_event.strip()
@@ -187,10 +200,11 @@ def main() -> int:
 
         if args.dry_run:
             result = dry_run_scenario(scenario)
+
         elif args.live:
             try:
                 assert args.target_url is not None
-                result = run_scenario_live(scenario, args.target_url)
+                result = run_scenario_live(scenario, args.target_url, timeout=args.target_timeout)
             except AdapterError as exc:
                 print(f"adapter error: {exc}", file=sys.stderr)
                 return 1

--- a/src/agent_harness/runner.py
+++ b/src/agent_harness/runner.py
@@ -59,9 +59,10 @@ def run_scenario_with_trace(scenario: Scenario, trace: Trace) -> HarnessResult:
     )
 
 
-def run_scenario_live(scenario: Scenario, target_url: str) -> HarnessResult:
+def run_scenario_live(scenario: Scenario, target_url: str, timeout: int = 30) -> HarnessResult:
     """Run a scenario against a live HTTP target."""
-    trace = run_http_target(scenario, target_url)
+    # Pass the timeout into the helper function
+    trace = run_http_target(scenario, target_url, timeout=timeout)
     assertion_results = evaluate_assertions(scenario, trace)
     top_level_result = aggregate_assertion_results(assertion_results)
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from agent_harness.adapters import (
     AdapterError,
     load_python_callable,
-    run_python_callable_target,
+    run_python_callable_target, run_http_target,
 )
 from agent_harness.trace import Trace
 from test_assertions import make_scenario
@@ -183,3 +185,24 @@ def test_load_python_callable_rejects_non_callable(tmp_path, monkeypatch):
 
     with pytest.raises(AdapterError, match="is not callable"):
         load_python_callable(f"{module_name}:NON_CALLABLE")
+
+
+@patch("urllib.request.urlopen")
+def test_run_http_target_respects_timeout(mock_urlopen):
+    """Verify the timeout parameter is passed to the underlying network call."""
+    # Create a Scenario object
+    scenario = make_scenario(assertions=[])
+
+    # Setup a fake response
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"messages": [], "tool_calls": [], "events": []}'
+    mock_response.__enter__.return_value = mock_response
+    mock_urlopen.return_value = mock_response
+
+    # Call the adapter with 45s timeout
+    target_url = "http://example.com/api"
+    custom_timeout = 45
+
+    run_http_target(scenario, target_url, timeout=custom_timeout)
+    args, kwargs = mock_urlopen.call_args
+    assert kwargs["timeout"] == custom_timeout

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from test_assertions import make_scenario
 
@@ -292,3 +294,28 @@ def test_python_async_callable_from_running_event_loop():
 
     trace = asyncio.run(run_from_loop())
     assert isinstance(trace, Trace)
+
+
+@patch("urllib.request.urlopen")
+def test_run_http_target_respects_timeout(mock_urlopen):
+    """Verify the timeout parameter is passed to the underlying network call."""
+    from agent_harness.adapters import run_http_target
+
+    #Create a real Scenario object
+    scenario = make_scenario(assertions=[])
+
+    #Setup a mock response to satisfy the JSON parsing step
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"messages": [], "tool_calls": [], "events": []}'
+    mock_response.__enter__.return_value = mock_response
+    mock_urlopen.return_value = mock_response
+
+    #Call the adapter with custom timeout
+    target_url = "http://127.0.0.1:8000/run"
+    custom_timeout = 45
+
+    run_http_target(scenario, target_url, timeout=custom_timeout)
+
+    # Assert that the underlying urlopen call received the parameter
+    _, kwargs = mock_urlopen.call_args
+    assert kwargs["timeout"] == custom_timeout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -736,3 +736,28 @@ def test_run_langchain_target_returns_adapter_error_for_bad_import(
     assert captured.out == ""
     assert "adapter error:" in captured.err
     assert "Could not import LangChain/LangGraph target module" in captured.err
+
+#New testcase to test the timeout
+def test_run_live_accepts_timeout_flag(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    # This ensures the CLI doesn't crash when the flag is provided
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--live",
+            "--target-url",
+            "http://127.0.0.1:1/run",
+            "--target-timeout",
+            "45",
+        ],
+    )
+
+    exit_code = main()
+    # Even if it fails to connect, we want to see it didn't fail on arg parsing
+    assert exit_code == 1


### PR DESCRIPTION
Fixes issue #92  

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
- In cli.py I added a target timeout parameter for custom adapter timeout
-  in adapter.py I changed run_http_target to pass the custom timeout value into urllib.request.urlopen
- added testcases in test_adapters.py and test_cli.py to verify that the target correctly passes the custom timeout value.
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code or documentation ?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance

**If you used AI assistance, briefly describe:**
- Tool(s) used: Gemini
- Parts of the contribution that were AI-assisted: The test cases
- How you reviewed the output: I checked it against the outlined json format
- Tests or checks I ran: I tested it manually using the command line and instructions outlined in the README

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every documentation, function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
- [ ] I added an entry under `[Unreleased]` in `CHANGELOG.md` (or this PR does not need one — pure refactor, internal tests, or CI-only change)