### PR TITLE
chore: de-duplicate coverage omit patterns in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,11 @@ warn_redundant_casts = true
 [tool.coverage.run]
 source = ["src/agent_harness"]
 omit = [
-    "src/agent_harness/*_adapter.py",
-    "src/agent_harness/mcp_*.py",
+    "src/agent_harness/langchain_adapter.py",
+    "src/agent_harness/mcp_adapter.py",
+    "src/agent_harness/mcp_host.py",
+    "src/agent_harness/mcp_runtime.py",
+    "src/agent_harness/openai_agents_adapter.py",
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,11 +81,9 @@ warn_redundant_casts = true
 [tool.coverage.run]
 source = ["src/agent_harness"]
 omit = [
-    "src/agent_harness/langchain_adapter.py",
-    "src/agent_harness/mcp_adapter.py",
+    "src/agent_harness/*_adapter.py",
     "src/agent_harness/mcp_host.py",
     "src/agent_harness/mcp_runtime.py",
-    "src/agent_harness/openai_agents_adapter.py",
 ]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
## Summary

`[tool.coverage.run].omit` used two globs (`*_adapter.py` and `mcp_*.py`) that both matched `mcp_adapter.py`, as flagged in #138. Keep the `*_adapter.py` glob so a new `<vendor>_adapter.py` is auto-omitted without touching config, and drop only the overlapping `mcp_*.py`, listing `mcp_host.py` and `mcp_runtime.py` explicitly. Each omitted file is now matched by exactly one rule.

## Verification

Ran `pytest --cov=src/agent_harness --cov-fail-under=80` before and after. The omit set and coverage are unchanged.

| Metric | Before | After |
| --- | --- | --- |
| Total coverage | 92.46% | 92.46% |
| Tests | 323 passed, 1 skipped | 323 passed, 1 skipped |

## Changelog

No `CHANGELOG.md` entry: internal coverage config change with no user-visible effect, per `CONTRIBUTING.md`.

## AI assistance disclosure

- Tool: Claude Code (Anthropic).
- Scope: applied the omit-config edit from the review (keep adapter glob, drop the `mcp_*.py` overlap), then ran the verification commands.
- Review: read the diff, confirmed the omit set still matches the same five files, compared pytest output before/after.
- Checks: `pytest --cov=src/agent_harness --cov-fail-under=80` run before and after. Identical results.

Fixes #138
