### PR TITLE
ci: assert regression_demo results are 'fail' to catch silent asserti…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,6 +128,24 @@ jobs:
               sys.exit(1)
           print("All security regression results pass (or not_run for unimplemented assertions).")
           PY
+      - name: Fail if any regression-demo result is not fail
+        run: |
+          python - <<'PY'
+          import json, pathlib, sys
+          not_failed = []
+          for path in pathlib.Path("regression_demo").glob("*.json"):
+              result = json.loads(path.read_text(encoding="utf-8"))
+              if result.get("result") != "fail":
+                  not_failed.append(
+                      f"{path.name}: {result['scenario_id']} returned {result['result']}"
+                  )
+          if not_failed:
+              print("Regression-demo failures detected:")
+              for item in not_failed:
+                  print(f"  - {item}")
+              sys.exit(1)
+          print("All regression-demo results correctly returned fail.")
+          PY
       - name: Upload result artifacts
         if: always()
         uses: actions/upload-artifact@v6

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -18,7 +18,8 @@ The `security-regression` job in `.github/workflows/tests.yml`:
 5. Runs trace-based harness checks against passing traces for representative scenarios (scenario validation is already covered by pytest)
 6. Dry-runs remaining scenarios that lack trace fixtures
 7. Reads every file in `results/` and exits 1 if any has `"result": "fail"` or `"result": "error"`
-8. Uploads result JSON files as artifacts (runs even on failure)
+8. Reads every file in `regression_demo/` and exits 1 if any does not have `"result": "fail"`
+9. Uploads result JSON files as artifacts (runs even on failure)
 
 ## How pass and fail actually work
 
@@ -41,15 +42,15 @@ agent-harness run scenarios/goal_hijack/basic.yaml \
 ```
 
 **Whole-suite gating** (used by this repository's committed workflow). Run
-every scenario without `--exit-on-fail`, write each result to `results/`, and
-add a final step that scans every JSON for `"result": "fail"` or
-`"result": "error"` and exits 1 if any is found. This is what the
-`security-regression` job does today; it allows a "regression demo" step
-(where a fail is expected) to live alongside passing steps by writing that
-result to a separate directory the scanner skips.
+every scenario without `--exit-on-fail`, write each result to `results/` for 
+clean traces and to `regression_demo/` for expected-fail traces.
+Add a step that scans every JSON in `results/` for a result that is
+`"result": "fail"` or `"result": "error"` and exits 1 if any is found. 
+Add a step that scans every JSON in `regression_demo/` for a result that is 
+not `"result": "fail"` (where a fail is expected) and exits 1 if any is found.
 
 A result of `"error"` means the harness did not complete the regression check
-correctly, so both approaches treat it as a CI failure.
+correctly, so both gate steps treat it as a CI failure.
 
 ```
 harness writes JSON → gate (flag or post-scan) decides exit code → job pass/fail
@@ -118,6 +119,7 @@ new scenarios.
 When you add a scenario to this repository, add a matching trace file to
 `examples/traces/` and a new run step to `.github/workflows/tests.yml`:
 
+### Clean traces
 ```yaml
 - name: Run my new scenario
   run: |
@@ -126,7 +128,18 @@ When you add a scenario to this repository, add a matching trace file to
       --out results/my_scenario.json
 ```
 
-The result-checking step picks up the new output file automatically.
+### Failing traces
+```yaml
+- name: Run my new scenario
+  run: |
+    agent-harness run scenarios/my_category/my_scenario.yaml \
+      --trace-file examples/traces/my_trace.json \
+      --out regression_demo/my_scenario.json
+```
+
+Add the scenario path to the exclusion list in the dry-run step to avoid running it twice.
+
+The result-checking steps pick up new output files automatically.
 
 ## Related
 

--- a/examples/traces/README.md
+++ b/examples/traces/README.md
@@ -53,6 +53,20 @@ Keep fixtures small. A few-line `messages` array, an empty
 `tool_calls`, and the necessary `events` (e.g. a `goal` event for
 `goal_integrity` assertions) is usually enough.
 
+## Adding a failing trace fixture
+
+When you add a scenario that has a failing trace:
+
+1. Create `examples/traces/<name>.json` with a trace that demonstrates
+   the failure — the agent took an action the scenario is designed to catch.
+2. Add a run step to `.github/workflows/tests.yml` writing the result
+   to `regression_demo/`.
+3. Run `agent-harness run scenarios/your_scenario.yaml --trace-file examples/traces/your_fixture.json`
+   to confirm.
+4. The `regression_demo/` gate will fail CI if the result is anything 
+   other than `fail`.
+
+
 ## Schema
 
 Trace JSON must be an object with three top-level fields, each a list


### PR DESCRIPTION
…on regressions

Fixes #137 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

-  Add a step to .github/workflows/tests.yml that fails if any result in regression_demo/ is anything other than `fail` (including pass, not_run, error).
-  Update docs/ci-github-actions.md 
  - Whole-suite gating: failing trace fixtures are now tracked and reported.
  - Adding a new scenario: Failing traces section and note to exclude from dry-run step

-  Update examples/traces/README.md
  - Add a failing trace fixture section

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code or documentation ?**
- [ ] No, I wrote all the code myself
- [X] Yes, I used AI assistance

**If you used AI assistance, briefly describe:**
- Tool(s) used: Claude.ai chat only
- Parts of the contribution that were AI-assisted: discussed the gate logic, variable naming, and documentation structure
- How you reviewed the output: wrote the code and documentation
- Tests or checks I ran: pytest and ruff

---

## Checklist before requesting a review
- [X] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [X] **I can explain the purpose of every documentation, function, class, and logic block I added**
- [X] I understand why my changes work and have tested them thoroughly
- [X] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [X] My code follows the project's style guidelines and conventions
- [X] I added an entry under `[Unreleased]` in `CHANGELOG.md` (or this PR does not need one — pure refactor, internal tests, or CI-only change)