### PR TITLE
feat(cli): add --target-timeout flag for live HTTP targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`approval_required` assertion** — fail when a sensitive action lacks a valid 
   approval event from a trusted `input.context` source. 
+- **`--target-timeout` flag** — configure the request timeout in seconds for live
+  HTTP targets via `agent-harness run --live` (default 30). 
 
 ## [0.1.0] — 2026-05-17
 

--- a/src/agent_harness/adapters.py
+++ b/src/agent_harness/adapters.py
@@ -18,6 +18,9 @@ class AdapterError(RuntimeError):
     """Raised when a target adapter fails."""
 
 
+DEFAULT_HTTP_TIMEOUT_SECONDS = 30
+
+
 def build_target_payload(scenario: Scenario) -> dict[str, Any]:
     """Build the payload sent to a target adapter."""
     return {
@@ -114,7 +117,12 @@ def load_python_callable(
     return target
 
 
-def run_http_target(scenario: Scenario, target_url: str) -> Trace:
+def run_http_target(
+    scenario: Scenario,
+    target_url: str,
+    *,
+    timeout: int = DEFAULT_HTTP_TIMEOUT_SECONDS,
+) -> Trace:
     """Run a scenario against an HTTP target and return its trace."""
     body = build_target_payload(scenario)
     request_data = json.dumps(body).encode("utf-8")
@@ -129,9 +137,13 @@ def run_http_target(scenario: Scenario, target_url: str) -> Trace:
     )
 
     try:
-        with request.urlopen(http_request, timeout=30) as response:
+        with request.urlopen(http_request, timeout=timeout) as response:
             response_text = response.read().decode("utf-8")
     except error.URLError as exc:
+        if isinstance(exc.reason, TimeoutError):
+            raise AdapterError(
+                f"HTTP target request timed out after {timeout} seconds"
+            ) from exc
         raise AdapterError(f"HTTP target request failed: {exc}") from exc
 
     try:

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from agent_harness.adapters import AdapterError
+from agent_harness.adapters import DEFAULT_HTTP_TIMEOUT_SECONDS, AdapterError
 from agent_harness.runner import (
     dry_run_scenario,
     run_scenario_live,
@@ -76,6 +76,14 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument(
         "--target-url",
         help="HTTP URL for the live target.",
+    )
+    run_parser.add_argument(
+        "--target-timeout",
+        type=int,
+        help=(
+            "Timeout in seconds for live HTTP target requests "
+            f"(default: {DEFAULT_HTTP_TIMEOUT_SECONDS})."
+        ),
     )
     run_parser.add_argument(
         "--python-target",
@@ -170,6 +178,12 @@ def main() -> int:
         if args.target_url and not args.live:
             parser.error("--target-url can only be used with --live")
 
+        if args.target_timeout is not None and not args.live:
+            parser.error("--target-timeout can only be used with --live")
+
+        if args.target_timeout is not None and args.target_timeout <= 0:
+            parser.error("--target-timeout must be greater than zero")
+
         if args.openai_agent_max_turns is not None and args.openai_agent is None:
             parser.error("--openai-agent-max-turns can only be used with --openai-agent")
 
@@ -199,7 +213,12 @@ def main() -> int:
         elif args.live:
             try:
                 assert args.target_url is not None
-                result = run_scenario_live(scenario, args.target_url)
+                timeout = (
+                    args.target_timeout
+                    if args.target_timeout is not None
+                    else DEFAULT_HTTP_TIMEOUT_SECONDS
+                )
+                result = run_scenario_live(scenario, args.target_url, timeout=timeout)
             except AdapterError as exc:
                 print(f"adapter error: {exc}", file=sys.stderr)
                 return 1

--- a/src/agent_harness/runner.py
+++ b/src/agent_harness/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from agent_harness.adapters import (
+    DEFAULT_HTTP_TIMEOUT_SECONDS,
     load_python_callable,
     load_python_object,
     run_http_target,
@@ -59,9 +60,14 @@ def run_scenario_with_trace(scenario: Scenario, trace: Trace) -> HarnessResult:
     )
 
 
-def run_scenario_live(scenario: Scenario, target_url: str) -> HarnessResult:
+def run_scenario_live(
+    scenario: Scenario,
+    target_url: str,
+    *,
+    timeout: int = DEFAULT_HTTP_TIMEOUT_SECONDS,
+) -> HarnessResult:
     """Run a scenario against a live HTTP target."""
-    trace = run_http_target(scenario, target_url)
+    trace = run_http_target(scenario, target_url, timeout=timeout)
     assertion_results = evaluate_assertions(scenario, trace)
     top_level_result = aggregate_assertion_results(assertion_results)
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+from urllib import error
+
 import pytest
 from test_assertions import make_scenario
 
 from agent_harness.adapters import (
     AdapterError,
     load_python_callable,
+    run_http_target,
     run_python_callable_target,
 )
 from agent_harness.trace import Trace
@@ -292,3 +296,46 @@ def test_python_async_callable_from_running_event_loop():
 
     trace = asyncio.run(run_from_loop())
     assert isinstance(trace, Trace)
+
+
+@patch("urllib.request.urlopen")
+def test_run_http_target_respects_timeout(mock_urlopen):
+    """The timeout argument is forwarded to the underlying network call."""
+    scenario = make_scenario(assertions=[])
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"messages": [], "tool_calls": [], "events": []}'
+    mock_response.__enter__.return_value = mock_response
+    mock_urlopen.return_value = mock_response
+
+    run_http_target(scenario, "http://127.0.0.1:8000/run", timeout=45)
+
+    _, kwargs = mock_urlopen.call_args
+    assert kwargs["timeout"] == 45
+
+
+@patch("urllib.request.urlopen")
+def test_run_http_target_defaults_to_thirty_second_timeout(mock_urlopen):
+    """Omitting the timeout falls back to the documented 30 second default."""
+    scenario = make_scenario(assertions=[])
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"messages": [], "tool_calls": [], "events": []}'
+    mock_response.__enter__.return_value = mock_response
+    mock_urlopen.return_value = mock_response
+
+    run_http_target(scenario, "http://127.0.0.1:8000/run")
+
+    _, kwargs = mock_urlopen.call_args
+    assert kwargs["timeout"] == 30
+
+
+@patch("urllib.request.urlopen")
+def test_run_http_target_reports_timeout_errors(mock_urlopen):
+    """A socket timeout surfaces as a clear AdapterError mentioning the limit."""
+    mock_urlopen.side_effect = error.URLError(TimeoutError("timed out"))
+
+    scenario = make_scenario(assertions=[])
+
+    with pytest.raises(AdapterError, match="timed out after 5 seconds"):
+        run_http_target(scenario, "http://127.0.0.1:8000/run", timeout=5)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 import sys
 
-from agent_harness.cli import VERSION, main
+import pytest
+
+from agent_harness.adapters import AdapterError
+from agent_harness.cli import VERSION, build_parser, main
 
 VALID_SCENARIO = """
 id: goal_hijack.basic_001
@@ -862,3 +865,135 @@ def test_run_langchain_target_returns_adapter_error_for_bad_import(
     assert captured.out == ""
     assert "adapter error:" in captured.err
     assert "Could not import LangChain/LangGraph target module" in captured.err
+
+
+def test_target_timeout_flag_parses():
+    parser = build_parser()
+
+    args = parser.parse_args(
+        [
+            "run",
+            "scenario.yaml",
+            "--live",
+            "--target-url",
+            "http://localhost/run",
+            "--target-timeout",
+            "45",
+        ]
+    )
+    assert args.target_timeout == 45
+
+    default_args = parser.parse_args(
+        ["run", "scenario.yaml", "--live", "--target-url", "http://localhost/run"]
+    )
+    assert default_args.target_timeout is None
+
+
+def test_run_live_passes_timeout_to_adapter(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    captured_kwargs: dict[str, int] = {}
+
+    def fake_run_scenario_live(scenario, target_url, *, timeout):
+        captured_kwargs["timeout"] = timeout
+        raise AdapterError("stop after capturing timeout")
+
+    monkeypatch.setattr("agent_harness.cli.run_scenario_live", fake_run_scenario_live)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--live",
+            "--target-url",
+            "http://127.0.0.1:1/run",
+            "--target-timeout",
+            "45",
+        ],
+    )
+
+    exit_code = main()
+
+    assert exit_code == 1
+    assert captured_kwargs["timeout"] == 45
+
+
+def test_run_live_defaults_timeout_to_thirty(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    captured_kwargs: dict[str, int] = {}
+
+    def fake_run_scenario_live(scenario, target_url, *, timeout):
+        captured_kwargs["timeout"] = timeout
+        raise AdapterError("stop after capturing timeout")
+
+    monkeypatch.setattr("agent_harness.cli.run_scenario_live", fake_run_scenario_live)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--live",
+            "--target-url",
+            "http://127.0.0.1:1/run",
+        ],
+    )
+
+    main()
+
+    assert captured_kwargs["timeout"] == 30
+
+
+def test_target_timeout_must_be_positive(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--live",
+            "--target-url",
+            "http://localhost/run",
+            "--target-timeout",
+            "0",
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert "--target-timeout must be greater than zero" in capsys.readouterr().err
+
+
+def test_target_timeout_requires_live(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--trace-file",
+            "trace.json",
+            "--target-timeout",
+            "10",
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert "--target-timeout can only be used with --live" in capsys.readouterr().err


### PR DESCRIPTION
Configurable request timeout for live HTTP targets via a new `--target-timeout` flag on `agent-harness run --live`.

Maintainer takeover of #135 (idle since the 2026-05-22 review), reimplemented on a clean topic branch and addressing all six review points there. Original work by @Hybried8, credited as co-author.

Fixes #92

### Changes
- New `--target-timeout <seconds>` flag (default 30) for live HTTP targets.
- Single `DEFAULT_HTTP_TIMEOUT_SECONDS` source of truth across cli / runner / adapter.
- Socket timeouts surface as a clear `AdapterError` naming the limit, via `isinstance(exc.reason, TimeoutError)` only — no error-message sniffing.
- Guards mirror the existing `--openai-agent-max-turns` pattern: requires `--live`, must be greater than zero.
- Tests: parser-level, value-propagation, default, timeout-error, and validation.
- CHANGELOG `[Unreleased]` entry.

### AI usage
Implemented with Claude Code (maintainer-driven). Reviewed and tested locally: ruff clean, mypy clean, full pytest suite 331 passed / 1 skipped at 92.57% coverage; manual CLI checks for the flag, guards, and timeout path.