### PR TITLE
ci: assert expected regression_demo result files are present

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,6 +128,24 @@ jobs:
               sys.exit(1)
           print("All security regression results pass (or not_run for unimplemented assertions).")
           PY
+      - name: Fail if any expected regression-demo file is missing
+        run: |
+          python - <<'PY'
+          import pathlib, sys
+          missing_files = []
+          expected_files = ["memory_isolation_leak.json", "approval_bypass_fake_token.json"]
+          target_directory = pathlib.Path("regression_demo")
+          for file in expected_files:
+              file_path = target_directory / file
+              if not file_path.is_file():
+                  missing_files.append(file_path)
+          if missing_files:
+              print("Expected regression-demo output files are missing:")
+              for item in missing_files:
+                  print(f"  - {item}")
+              sys.exit(1)
+          print("All expected regression-demo output files exist.")
+          PY
       - name: Fail if any regression-demo result is not fail
         run: |
           python - <<'PY'

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -139,7 +139,10 @@ When you add a scenario to this repository, add a matching trace file to
 
 Add the scenario path to the exclusion list in the dry-run step to avoid running it twice.
 
-The result-checking steps pick up new output files automatically.
+The result-checking steps pick up new output files automatically. For `regression_demo/` 
+entries, also add the expected filename to `.github/workflows/tests.yml` to the expected_files 
+list in the "Fail if any expected regression-demo file is missing" step to prevent the gate 
+from passing vacuously if the demo step stops emitting.
 
 ## Related
 

--- a/examples/traces/README.md
+++ b/examples/traces/README.md
@@ -61,10 +61,13 @@ When you add a scenario that has a failing trace:
    the failure — the agent took an action the scenario is designed to catch.
 2. Add a run step to `.github/workflows/tests.yml` writing the result
    to `regression_demo/`.
-3. Run `agent-harness run scenarios/your_scenario.yaml --trace-file examples/traces/your_fixture.json`
+3. Add the output filename from your run step to `.github/workflows/tests.yml` 
+   to the expected_files list in "Fail if any expected regression-demo file is 
+   missing" step.
+4. Run `agent-harness run scenarios/your_scenario.yaml --trace-file examples/traces/your_fixture.json`
    to confirm.
-4. The `regression_demo/` gate will fail CI if the result is anything 
-   other than `fail`.
+5. The `regression_demo/` gate will fail CI if the step does not emit a file or if the result is 
+   anything other than `fail`.
 
 
 ## Schema


### PR DESCRIPTION
Fixes #144 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
- Add to `.github/workflows/tests.yml` an assertion step for presence of expected regression-demo files
- Update `examples/traces/README.md` instructions for "Adding a failing trace fixture"
- Update `docs/ci-github-actions.md` instructions for "Adding a new scenario"
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code or documentation ?**
- [ ] No, I wrote all the code myself
- [X] Yes, I used AI assistance

**If you used AI assistance, briefly describe:**
- Tool(s) used: claude.ai chat
- Parts of the contribution that were AI-assisted: discussed architecture and other potential failure scenarios
- How you reviewed the output: wrote the code and documentation myself 
- Tests or checks I ran: ruff and pytest

---

## Checklist before requesting a review
- [X] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [X] **I can explain the purpose of every documentation, function, class, and logic block I added**
- [X] I understand why my changes work and have tested them thoroughly
- [X] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [X] My code follows the project's style guidelines and conventions
- [ ] I added an entry under `[Unreleased]` in `CHANGELOG.md` (or this PR does not need one — pure refactor, internal tests, or CI-only change)