### PR TITLE
feat(cli): validate scenario directories and globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support recursive directory and glob validation in `agent-harness validate`.
 - **`approval_required` assertion** — fail when a sensitive action lacks a valid 
   approval event from a trusted `input.context` source. 
 - **`--target-timeout` flag** — configure the request timeout in seconds for live

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -21,6 +21,24 @@ The `security-regression` job in `.github/workflows/tests.yml`:
 8. Reads every file in `regression_demo/` and exits 1 if any does not have `"result": "fail"`
 9. Uploads result JSON files as artifacts (runs even on failure)
 
+## Validate a scenario suite
+
+The `validate` command accepts one scenario file, a directory, or a glob. Directory
+validation is recursive, prints one result per scenario, and exits non-zero if any
+scenario is invalid:
+
+```bash
+agent-harness validate scenarios/
+```
+
+Globs are useful when a workflow only needs to validate part of a suite:
+
+```bash
+agent-harness validate "scenarios/mcp_trust_boundary/**/*.yaml"
+```
+
+Both forms finish with a summary count of valid and invalid scenarios.
+
 ## How pass and fail actually work
 
 `agent-harness run` writes machine-readable result JSON to the path you give

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import glob
 import sys
 from pathlib import Path
 
@@ -20,6 +21,54 @@ from agent_harness.scenario import ScenarioValidationError, load_scenario
 from agent_harness.trace import TraceValidationError, load_trace
 
 VERSION = "0.1.0"
+SCENARIO_SUFFIXES = {".yaml", ".yml"}
+
+
+def _scenario_files(path_expression: str) -> list[Path]:
+    path = Path(path_expression)
+
+    if path.is_dir():
+        return sorted(
+            candidate
+            for candidate in path.rglob("*")
+            if candidate.is_file() and candidate.suffix.lower() in SCENARIO_SUFFIXES
+        )
+
+    if glob.has_magic(path_expression):
+        return sorted(
+            {
+                Path(match)
+                for match in glob.glob(path_expression, recursive=True)
+                if Path(match).is_file()
+                and Path(match).suffix.lower() in SCENARIO_SUFFIXES
+            }
+        )
+
+    return [path]
+
+
+def _validate_scenarios(path_expression: str) -> int:
+    scenario_files = _scenario_files(path_expression)
+    if not scenario_files:
+        print(f"invalid: no scenario files found: {path_expression}", file=sys.stderr)
+        print("summary: 0 valid, 0 invalid")
+        return 1
+
+    valid_count = 0
+    invalid_count = 0
+    for scenario_file in scenario_files:
+        try:
+            scenario = load_scenario(scenario_file)
+        except ScenarioValidationError as exc:
+            invalid_count += 1
+            print(f"invalid: {scenario_file}: {exc}", file=sys.stderr)
+            continue
+
+        valid_count += 1
+        print(f"valid: {scenario_file}: {scenario.id}")
+
+    print(f"summary: {valid_count} valid, {invalid_count} invalid")
+    return 1 if invalid_count else 0
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -44,7 +93,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     validate_parser.add_argument(
         "scenario_file",
-        help="Path to the scenario YAML file.",
+        help="Path, directory, or glob of scenario YAML files.",
     )
 
     run_parser = subparsers.add_parser(
@@ -145,14 +194,7 @@ def main() -> int:
         return 0
 
     if args.command == "validate":
-        try:
-            scenario = load_scenario(args.scenario_file)
-        except ScenarioValidationError as exc:
-            print(f"invalid: {exc}", file=sys.stderr)
-            return 1
-
-        print(f"valid: {scenario.id}")
-        return 0
+        return _validate_scenarios(args.scenario_file)
 
     if args.command == "run":
         selected_modes = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,7 +55,10 @@ def test_validate_command_accepts_valid_scenario(capsys, monkeypatch, tmp_path):
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert captured.out.strip() == "valid: goal_hijack.basic_001"
+    assert captured.out.splitlines() == [
+        f"valid: {scenario_file}: goal_hijack.basic_001",
+        "summary: 1 valid, 0 invalid",
+    ]
 
 
 def test_validate_command_rejects_missing_fields(capsys, monkeypatch, tmp_path):
@@ -69,6 +72,64 @@ def test_validate_command_rejects_missing_fields(capsys, monkeypatch, tmp_path):
     captured = capsys.readouterr()
 
     assert exit_code == 1
+    assert "missing required fields" in captured.err
+    assert captured.out.strip() == "summary: 0 valid, 1 invalid"
+
+
+def test_validate_command_recursively_accepts_valid_scenarios(
+    capsys, monkeypatch, tmp_path
+):
+    scenarios_dir = tmp_path / "scenarios"
+    nested_dir = scenarios_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    first_scenario = scenarios_dir / "first.yaml"
+    second_scenario = nested_dir / "second.yml"
+    first_scenario.write_text(VALID_SCENARIO, encoding="utf-8")
+    second_scenario.write_text(
+        VALID_SCENARIO.replace("goal_hijack.basic_001", "goal_hijack.second_001"),
+        encoding="utf-8",
+    )
+    (nested_dir / "notes.txt").write_text("not a scenario", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", ["agent-harness", "validate", str(scenarios_dir)])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out.splitlines() == [
+        f"valid: {first_scenario}: goal_hijack.basic_001",
+        f"valid: {second_scenario}: goal_hijack.second_001",
+        "summary: 2 valid, 0 invalid",
+    ]
+    assert captured.err == ""
+
+
+def test_validate_command_glob_fails_when_any_scenario_is_invalid(
+    capsys, monkeypatch, tmp_path
+):
+    valid_scenario = tmp_path / "valid.yaml"
+    invalid_scenario = tmp_path / "invalid.yml"
+    valid_scenario.write_text(VALID_SCENARIO, encoding="utf-8")
+    invalid_scenario.write_text("id: broken.scenario\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent-harness", "validate", str(tmp_path / "*.y*ml")],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out.splitlines() == [
+        f"valid: {valid_scenario}: goal_hijack.basic_001",
+        "summary: 1 valid, 1 invalid",
+    ]
+    assert f"invalid: {invalid_scenario}:" in captured.err
     assert "missing required fields" in captured.err
 
 


### PR DESCRIPTION
## Summary
- allow `agent-harness validate` to accept a file, directory, or glob
- recursively discover YAML scenarios and print one result per file
- return non-zero when any scenario is invalid and print summary counts
- document directory/glob validation for CI workflows

## Tests
- `python -m pytest -q` (333 passed, 1 skipped)
- `python -m ruff check src tests`
- `python -m mypy src/agent_harness`

Closes #84

## AI assistance disclosure
OpenAI Codex assisted with the implementation, tests, and documentation. I reviewed the changed code and verified it with the full pytest suite, Ruff, and mypy. I remain responsible for the contribution.