### PR TITLE
feat: add recursive scenario validation for directories and glob patterns (issue #84)

### DIFF
--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -141,6 +141,20 @@ Add the scenario path to the exclusion list in the dry-run step to avoid running
 
 The result-checking steps pick up new output files automatically.
 
+## Batch scenario validation
+
+`agent-harness validate` now accepts directories and glob patterns in addition
+to single files. Use it as a fast pre-flight check before running scenarios:
+
+```yaml
+- name: Validate all scenarios
+  run: agent-harness validate scenarios/
+```
+
+This validates every `.yaml`/`.yml` file recursively under `scenarios/`,
+prints one line per scenario, and exits non-zero if any are invalid. A summary
+line shows the count of valid and invalid scenarios.
+
 ## Related
 
 - [Trace format](trace-format.md)

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import glob as glob_module
 import sys
 from pathlib import Path
 
@@ -20,6 +21,42 @@ from agent_harness.scenario import ScenarioValidationError, load_scenario
 from agent_harness.trace import TraceValidationError, load_trace
 
 VERSION = "0.1.0"
+
+
+def _collect_scenario_files(path: str) -> list[Path]:
+    """Resolve a file, directory, or glob pattern to a list of .yaml/.yml paths."""
+    p = Path(path)
+
+    if p.is_dir():
+        return sorted(
+            f for f in p.rglob("*")
+            if f.suffix.lower() in {".yaml", ".yml"}
+        )
+
+    if any(c in path for c in "*?[]"):
+        return sorted(
+            Path(f) for f in glob_module.glob(path, recursive=True)
+            if Path(f).suffix.lower() in {".yaml", ".yml"}
+        )
+
+    return [p]
+
+
+def _run_validate(files: list[Path]) -> tuple[int, int, int]:
+    """Validate a list of scenario files. Returns (valid, invalid, total)."""
+    valid = invalid = 0
+
+    for f in files:
+        label = str(f)
+        try:
+            scenario = load_scenario(f)
+            print(f"valid: {scenario.id}  ({label})")
+            valid += 1
+        except ScenarioValidationError as exc:
+            print(f"invalid: {exc}  ({label})", file=sys.stderr)
+            invalid += 1
+
+    return valid, invalid, valid + invalid
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -40,11 +77,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     validate_parser = subparsers.add_parser(
         "validate",
-        help="Validate a scenario file.",
+        help="Validate one or more scenario files.",
     )
     validate_parser.add_argument(
         "scenario_file",
-        help="Path to the scenario YAML file.",
+        help="Path to a scenario file, directory, or glob pattern.",
     )
 
     run_parser = subparsers.add_parser(
@@ -145,14 +182,18 @@ def main() -> int:
         return 0
 
     if args.command == "validate":
-        try:
-            scenario = load_scenario(args.scenario_file)
-        except ScenarioValidationError as exc:
-            print(f"invalid: {exc}", file=sys.stderr)
+        files = _collect_scenario_files(args.scenario_file)
+
+        if not files:
+            print(f"no scenario files found in: {args.scenario_file}", file=sys.stderr)
             return 1
 
-        print(f"valid: {scenario.id}")
-        return 0
+        valid, invalid, total = _run_validate(files)
+
+        if total > 1:
+            print(f"\n{valid} valid, {invalid} invalid ({total} total)")
+
+        return 1 if invalid > 0 else 0
 
     if args.command == "run":
         selected_modes = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -997,3 +997,87 @@ def test_target_timeout_requires_live(capsys, monkeypatch, tmp_path):
         main()
 
     assert "--target-timeout can only be used with --live" in capsys.readouterr().err
+
+
+# --- Recursive scenario validation (issue #84) ---
+
+
+def test_validate_directory_all_valid(capsys, monkeypatch, tmp_path):
+    sub = tmp_path / "scenarios"
+    sub.mkdir()
+    (sub / "a.yaml").write_text(VALID_SCENARIO, encoding="utf-8")
+    (sub / "b.yaml").write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", ["agent-harness", "validate", str(sub)])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "valid: goal_hijack.basic_001" in captured.out
+    assert "2 valid, 0 invalid (2 total)" in captured.out
+
+
+def test_validate_directory_mixed_validity(capsys, monkeypatch, tmp_path):
+    sub = tmp_path / "scenarios"
+    sub.mkdir()
+    (sub / "good.yaml").write_text(VALID_SCENARIO, encoding="utf-8")
+    (sub / "bad.yaml").write_text("id: broken.scenario\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", ["agent-harness", "validate", str(sub)])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "valid: goal_hijack.basic_001" in captured.out
+    assert "missing required fields" in captured.err
+    assert "1 valid, 1 invalid (2 total)" in captured.out
+
+
+def test_validate_directory_empty(tmp_path, monkeypatch, capsys):
+    sub = tmp_path / "empty"
+    sub.mkdir()
+
+    monkeypatch.setattr(sys, "argv", ["agent-harness", "validate", str(sub)])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "no scenario files found" in captured.err
+
+
+def test_validate_glob_pattern(capsys, monkeypatch, tmp_path):
+    sub = tmp_path / "scenarios"
+    sub.mkdir()
+    (sub / "one.yaml").write_text(VALID_SCENARIO, encoding="utf-8")
+    (sub / "two.yaml").write_text(VALID_SCENARIO, encoding="utf-8")
+
+    pattern = str(sub / "*.yaml")
+    monkeypatch.setattr(sys, "argv", ["agent-harness", "validate", pattern])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "2 valid, 0 invalid (2 total)" in captured.out
+
+
+def test_validate_single_file_still_works(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys, "argv", ["agent-harness", "validate", str(scenario_file)]
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == "valid: goal_hijack.basic_001  ({})".format(
+        scenario_file
+    )
+    # No summary line for single file
+    assert "total" not in captured.out


### PR DESCRIPTION
## Summary
The agent-harness validate command now supports directories (recursive), glob patterns, and single files. Per-file status output with summary count. Exits non-zero if any scenario fails for CI pipelines.

## Changes
- src/agent_harness/cli.py: Added _collect_scenario_files() and _run_validate()
- tests/test_cli.py: 5 new tests (dir, mixed, empty, glob, single-file)
- docs/ci-github-actions.md: Batch validation workflow example

Closes #84