### PR TITLE
feat: support live HTTP target headers

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -635,6 +635,22 @@ agent-harness run scenarios/goal_hijack/basic.yaml \
   --target-url http://127.0.0.1:8000/run
 ```
 
+Targets that need request headers can receive them from the CLI instead of
+from the scenario file:
+
+```bash
+agent-harness run scenarios/goal_hijack/basic.yaml \
+  --live \
+  --target-url http://127.0.0.1:8000/run \
+  --target-header 'Authorization=Bearer token-from-env' \
+  --target-header 'X-Tenant=local-dev'
+```
+
+Use shell environment variables or your CI secret store to construct secret
+header values. Header values are sent only to the live HTTP target request;
+they are not added to the scenario payload, trace, or result JSON by the
+harness.
+
 Request body:
 
 ```json

--- a/src/agent_harness/adapters.py
+++ b/src/agent_harness/adapters.py
@@ -122,17 +122,22 @@ def run_http_target(
     target_url: str,
     *,
     timeout: int = DEFAULT_HTTP_TIMEOUT_SECONDS,
+    headers: dict[str, str] | None = None,
 ) -> Trace:
     """Run a scenario against an HTTP target and return its trace."""
     body = build_target_payload(scenario)
     request_data = json.dumps(body).encode("utf-8")
+    request_headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    if headers:
+        request_headers.update(headers)
+
     http_request = request.Request(
         target_url,
         data=request_data,
-        headers={
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        },
+        headers=request_headers,
         method="POST",
     )
 

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -20,6 +21,29 @@ from agent_harness.scenario import ScenarioValidationError, load_scenario
 from agent_harness.trace import TraceValidationError, load_trace
 
 VERSION = "0.1.0"
+HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+
+
+def parse_target_headers(raw_headers: list[str] | None) -> dict[str, str]:
+    """Parse NAME=VALUE HTTP header arguments for live target requests."""
+    parsed: dict[str, str] = {}
+    for raw_header in raw_headers or []:
+        if "=" not in raw_header:
+            raise ValueError("header must use NAME=VALUE format")
+
+        name, value = raw_header.split("=", 1)
+        name = name.strip()
+
+        if not name:
+            raise ValueError("header name must not be empty")
+        if not HEADER_NAME_RE.fullmatch(name):
+            raise ValueError(f"invalid header name: {name!r}")
+        if "\r" in value or "\n" in value:
+            raise ValueError(f"header {name!r} must not contain newlines")
+
+        parsed[name] = value
+
+    return parsed
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -83,6 +107,16 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Timeout in seconds for live HTTP target requests "
             f"(default: {DEFAULT_HTTP_TIMEOUT_SECONDS})."
+        ),
+    )
+    run_parser.add_argument(
+        "--target-header",
+        action="append",
+        metavar="NAME=VALUE",
+        help=(
+            "Optional HTTP header for live target requests. Repeat for multiple "
+            "headers. Header values are sent to the target only and are not "
+            "stored in scenario files or result JSON."
         ),
     )
     run_parser.add_argument(
@@ -181,8 +215,16 @@ def main() -> int:
         if args.target_timeout is not None and not args.live:
             parser.error("--target-timeout can only be used with --live")
 
+        if args.target_header is not None and not args.live:
+            parser.error("--target-header can only be used with --live")
+
         if args.target_timeout is not None and args.target_timeout <= 0:
             parser.error("--target-timeout must be greater than zero")
+
+        try:
+            target_headers = parse_target_headers(args.target_header)
+        except ValueError as exc:
+            parser.error(f"--target-header {exc}")
 
         if args.openai_agent_max_turns is not None and args.openai_agent is None:
             parser.error("--openai-agent-max-turns can only be used with --openai-agent")
@@ -218,7 +260,12 @@ def main() -> int:
                     if args.target_timeout is not None
                     else DEFAULT_HTTP_TIMEOUT_SECONDS
                 )
-                result = run_scenario_live(scenario, args.target_url, timeout=timeout)
+                result = run_scenario_live(
+                    scenario,
+                    args.target_url,
+                    timeout=timeout,
+                    headers=target_headers,
+                )
             except AdapterError as exc:
                 print(f"adapter error: {exc}", file=sys.stderr)
                 return 1

--- a/src/agent_harness/runner.py
+++ b/src/agent_harness/runner.py
@@ -65,9 +65,10 @@ def run_scenario_live(
     target_url: str,
     *,
     timeout: int = DEFAULT_HTTP_TIMEOUT_SECONDS,
+    headers: dict[str, str] | None = None,
 ) -> HarnessResult:
     """Run a scenario against a live HTTP target."""
-    trace = run_http_target(scenario, target_url, timeout=timeout)
+    trace = run_http_target(scenario, target_url, timeout=timeout, headers=headers)
     assertion_results = evaluate_assertions(scenario, trace)
     top_level_result = aggregate_assertion_results(assertion_results)
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -331,6 +331,31 @@ def test_run_http_target_defaults_to_thirty_second_timeout(mock_urlopen):
 
 
 @patch("urllib.request.urlopen")
+def test_run_http_target_sends_custom_headers(mock_urlopen):
+    """Custom HTTP headers are sent to the target request only."""
+    scenario = make_scenario(assertions=[])
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"messages": [], "tool_calls": [], "events": []}'
+    mock_response.__enter__.return_value = mock_response
+    mock_urlopen.return_value = mock_response
+
+    run_http_target(
+        scenario,
+        "http://127.0.0.1:8000/run",
+        headers={
+            "Authorization": "Bearer test-secret",
+            "X-Tenant": "local-dev",
+        },
+    )
+
+    http_request = mock_urlopen.call_args.args[0]
+    assert http_request.get_header("Authorization") == "Bearer test-secret"
+    assert http_request.get_header("X-tenant") == "local-dev"
+    assert b"test-secret" not in http_request.data
+
+
+@patch("urllib.request.urlopen")
 def test_run_http_target_reports_timeout_errors(mock_urlopen):
     """A socket timeout surfaces as a clear AdapterError mentioning the limit."""
     mock_urlopen.side_effect = error.URLError(TimeoutError("timed out"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -889,13 +889,33 @@ def test_target_timeout_flag_parses():
     assert default_args.target_timeout is None
 
 
+def test_target_header_flag_parses_multiple_headers():
+    parser = build_parser()
+
+    args = parser.parse_args(
+        [
+            "run",
+            "scenario.yaml",
+            "--live",
+            "--target-url",
+            "http://localhost/run",
+            "--target-header",
+            "Authorization=Bearer token",
+            "--target-header",
+            "X-Tenant=local-dev",
+        ]
+    )
+
+    assert args.target_header == ["Authorization=Bearer token", "X-Tenant=local-dev"]
+
+
 def test_run_live_passes_timeout_to_adapter(capsys, monkeypatch, tmp_path):
     scenario_file = tmp_path / "scenario.yaml"
     scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
 
     captured_kwargs: dict[str, int] = {}
 
-    def fake_run_scenario_live(scenario, target_url, *, timeout):
+    def fake_run_scenario_live(scenario, target_url, *, timeout, headers):
         captured_kwargs["timeout"] = timeout
         raise AdapterError("stop after capturing timeout")
 
@@ -921,13 +941,51 @@ def test_run_live_passes_timeout_to_adapter(capsys, monkeypatch, tmp_path):
     assert captured_kwargs["timeout"] == 45
 
 
+def test_run_live_passes_headers_to_adapter(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_run_scenario_live(scenario, target_url, *, timeout, headers):
+        captured_kwargs["headers"] = headers
+        raise AdapterError("stop after capturing headers")
+
+    monkeypatch.setattr("agent_harness.cli.run_scenario_live", fake_run_scenario_live)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--live",
+            "--target-url",
+            "http://127.0.0.1:1/run",
+            "--target-header",
+            "Authorization=Bearer test-secret",
+            "--target-header",
+            "X-Tenant=local-dev",
+        ],
+    )
+
+    exit_code = main()
+
+    assert exit_code == 1
+    assert captured_kwargs["headers"] == {
+        "Authorization": "Bearer test-secret",
+        "X-Tenant": "local-dev",
+    }
+    assert "test-secret" not in capsys.readouterr().err
+
+
 def test_run_live_defaults_timeout_to_thirty(capsys, monkeypatch, tmp_path):
     scenario_file = tmp_path / "scenario.yaml"
     scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
 
     captured_kwargs: dict[str, int] = {}
 
-    def fake_run_scenario_live(scenario, target_url, *, timeout):
+    def fake_run_scenario_live(scenario, target_url, *, timeout, headers):
         captured_kwargs["timeout"] = timeout
         raise AdapterError("stop after capturing timeout")
 
@@ -973,6 +1031,55 @@ def test_target_timeout_must_be_positive(capsys, monkeypatch, tmp_path):
         main()
 
     assert "--target-timeout must be greater than zero" in capsys.readouterr().err
+
+
+def test_target_header_requires_live(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--trace-file",
+            "trace.json",
+            "--target-header",
+            "Authorization=Bearer test-secret",
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert "--target-header can only be used with --live" in capsys.readouterr().err
+
+
+def test_target_header_rejects_malformed_header(capsys, monkeypatch, tmp_path):
+    scenario_file = tmp_path / "scenario.yaml"
+    scenario_file.write_text(VALID_SCENARIO, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--live",
+            "--target-url",
+            "http://localhost/run",
+            "--target-header",
+            "Authorization",
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert "--target-header header must use NAME=VALUE format" in capsys.readouterr().err
 
 
 def test_target_timeout_requires_live(capsys, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add repeatable `--target-header NAME=VALUE` support for live HTTP targets
- validate header names/input and reject headers outside `--live`
- pass headers only to the HTTP request, not the scenario payload, trace, or result JSON
- document safe usage for auth/routing headers

Fixes #93.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_adapters.py tests/test_cli.py`
- `PYTHONPATH=src python3 -m compileall -q src/agent_harness tests/test_adapters.py tests/test_cli.py`
- `git diff --check`

Note: `python3 -m ruff ...` was not available in this local environment (`No module named ruff`).
