### PR TITLE
feat(cli): validate scenario directories and globs

### DIFF
--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -21,6 +21,38 @@ The `security-regression` job in `.github/workflows/tests.yml`:
 8. Reads every file in `regression_demo/` and exits 1 if any does not have `"result": "fail"`
 9. Uploads result JSON files as artifacts (runs even on failure)
 
+## Validating scenarios
+
+`agent-harness validate` accepts scenario files, directories, and glob patterns.
+Directories are searched recursively for `.yaml` and `.yml` files. The command
+prints one line per scenario, prints a summary, and exits 1 if any scenario is
+invalid.
+
+Validate one file:
+
+```bash
+agent-harness validate scenarios/goal_hijack/basic.yaml
+```
+
+Validate every scenario in a directory:
+
+```bash
+agent-harness validate scenarios/
+```
+
+Validate a glob, including nested folders:
+
+```bash
+agent-harness validate "scenarios/**/*.yaml"
+```
+
+Example CI step:
+
+```yaml
+- name: Validate security scenarios
+  run: agent-harness validate "scenarios/**/*.yaml"
+```
+
 ## How pass and fail actually work
 
 `agent-harness run` writes machine-readable result JSON to the path you give

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import glob
 import sys
 from pathlib import Path
 
@@ -20,6 +21,34 @@ from agent_harness.scenario import ScenarioValidationError, load_scenario
 from agent_harness.trace import TraceValidationError, load_trace
 
 VERSION = "0.1.0"
+
+
+def _discover_scenario_files(patterns: list[str]) -> list[Path]:
+    """Return unique scenario files matched by files, directories, or globs."""
+    scenario_files: list[Path] = []
+    seen: set[Path] = set()
+
+    for pattern in patterns:
+        path = Path(pattern)
+        if path.is_dir():
+            matches = sorted(
+                matched
+                for suffix in ("*.yaml", "*.yml")
+                for matched in path.rglob(suffix)
+                if matched.is_file()
+            )
+        else:
+            glob_matches = sorted(Path(match) for match in glob.glob(pattern, recursive=True))
+            matches = glob_matches if glob_matches else [path]
+
+        for match in matches:
+            normalized = match.resolve()
+            if normalized in seen or not match.is_file():
+                continue
+            seen.add(normalized)
+            scenario_files.append(match)
+
+    return scenario_files
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -40,11 +69,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     validate_parser = subparsers.add_parser(
         "validate",
-        help="Validate a scenario file.",
+        help="Validate scenario files, directories, or glob patterns.",
     )
     validate_parser.add_argument(
-        "scenario_file",
-        help="Path to the scenario YAML file.",
+        "scenario_paths",
+        nargs="+",
+        help="Scenario YAML file, directory, or glob pattern to validate.",
     )
 
     run_parser = subparsers.add_parser(
@@ -145,14 +175,28 @@ def main() -> int:
         return 0
 
     if args.command == "validate":
-        try:
-            scenario = load_scenario(args.scenario_file)
-        except ScenarioValidationError as exc:
-            print(f"invalid: {exc}", file=sys.stderr)
+        scenario_files = _discover_scenario_files(args.scenario_paths)
+        if not scenario_files:
+            print("invalid: no scenario files matched", file=sys.stderr)
             return 1
 
-        print(f"valid: {scenario.id}")
-        return 0
+        valid_count = 0
+        invalid_count = 0
+
+        for scenario_file in scenario_files:
+            try:
+                scenario = load_scenario(scenario_file)
+            except ScenarioValidationError as exc:
+                invalid_count += 1
+                print(f"invalid: {scenario_file}: {exc}", file=sys.stderr)
+                continue
+
+            valid_count += 1
+            print(f"valid: {scenario_file}: {scenario.id}")
+
+        print(f"summary: {valid_count} valid, {invalid_count} invalid")
+        return 1 if invalid_count else 0
+
 
     if args.command == "run":
         selected_modes = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,7 +55,8 @@ def test_validate_command_accepts_valid_scenario(capsys, monkeypatch, tmp_path):
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert captured.out.strip() == "valid: goal_hijack.basic_001"
+    assert f"valid: {scenario_file}: goal_hijack.basic_001" in captured.out
+    assert "summary: 1 valid, 0 invalid" in captured.out
 
 
 def test_validate_command_rejects_missing_fields(capsys, monkeypatch, tmp_path):
@@ -70,6 +71,53 @@ def test_validate_command_rejects_missing_fields(capsys, monkeypatch, tmp_path):
 
     assert exit_code == 1
     assert "missing required fields" in captured.err
+    assert "summary: 0 valid, 1 invalid" in captured.out
+
+
+def test_validate_command_accepts_recursive_directory(capsys, monkeypatch, tmp_path):
+    scenarios_dir = tmp_path / "scenarios"
+    nested_dir = scenarios_dir / "goal_hijack"
+    nested_dir.mkdir(parents=True)
+    first_scenario = scenarios_dir / "basic.yaml"
+    second_scenario = nested_dir / "nested.yml"
+    first_scenario.write_text(VALID_SCENARIO, encoding="utf-8")
+    second_scenario.write_text(
+        VALID_SCENARIO.replace("goal_hijack.basic_001", "goal_hijack.nested_001"),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(sys, "argv", ["agent-harness", "validate", str(scenarios_dir)])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert f"valid: {first_scenario}: goal_hijack.basic_001" in captured.out
+    assert f"valid: {second_scenario}: goal_hijack.nested_001" in captured.out
+    assert "summary: 2 valid, 0 invalid" in captured.out
+
+
+def test_validate_command_exits_nonzero_for_mixed_glob(capsys, monkeypatch, tmp_path):
+    valid_scenario = tmp_path / "valid.yaml"
+    invalid_scenario = tmp_path / "invalid.yaml"
+    valid_scenario.write_text(VALID_SCENARIO, encoding="utf-8")
+    invalid_scenario.write_text("id: broken.scenario\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent-harness", "validate", str(tmp_path / "*.yaml")],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert f"valid: {valid_scenario}: goal_hijack.basic_001" in captured.out
+    assert f"invalid: {invalid_scenario}: missing required fields" in captured.err
+    assert "summary: 1 valid, 1 invalid" in captured.out
 
 
 def test_run_dry_run_outputs_result_json(capsys, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Closes #84.

Adds recursive batch validation support to `agent-harness validate` so CI and local users can validate scenario files by file path, directory, or glob pattern.

## Changes

- Accept one or more scenario files, directories, or glob patterns for `agent-harness validate`
- Recursively discover `.yaml` and `.yml` files under directories
- Print one clear line per scenario plus a valid/invalid summary
- Exit non-zero when any matched scenario is invalid
- Add CLI tests for single-file, recursive directory, and mixed-validity glob validation
- Document the validation workflow in the GitHub Actions guide

## Validation

- `python -m pytest tests/test_cli.py`
- `python -m ruff check src tests`
- `python -m pytest`
- `python -m mypy`
- `python -m agent_harness.cli validate scenarios`