### PR TITLE
feat: add JUnit XML output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--junit-out` flag** — write assertion results as JUnit XML for CI
+  systems while preserving the existing result JSON output.
 - **`approval_required` assertion** — fail when a sensitive action lacks a valid 
   approval event from a trusted `input.context` source. 
 - **`--target-timeout` flag** — configure the request timeout in seconds for live

--- a/README.md
+++ b/README.md
@@ -231,6 +231,19 @@ agent-harness run scenarios/goal_hijack/basic.yaml --trace-file examples/traces/
 agent-harness run scenarios/goal_hijack/basic.yaml --live --target-url http://127.0.0.1:8000/run --out result.json
 ```
 
+### 9. Write JUnit XML for CI systems
+
+All run modes also support `--junit-out`. The harness still prints result JSON
+to stdout unless `--out` is provided, and writes one JUnit testcase per
+assertion:
+
+```bash
+agent-harness run scenarios/goal_hijack/basic.yaml \
+  --trace-file examples/traces/denied_tool_call.json \
+  --out result.json \
+  --junit-out result.xml
+```
+
 ## Live HTTP target contract
 
 Live mode expects an HTTP target that accepts a `POST` request.

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -27,6 +27,16 @@ The `security-regression` job in `.github/workflows/tests.yml`:
 `--out`. The `result` field in that JSON will be `pass`, `fail`, `not_run`,
 or `error`.
 
+For CI systems that ingest JUnit XML, also pass `--junit-out <path>`. This
+writes one testcase per assertion while preserving the result JSON output:
+
+```bash
+agent-harness run scenarios/goal_hijack/basic.yaml \
+  --trace-file examples/traces/no_denied_tool_call.json \
+  --out results/basic.json \
+  --junit-out results/basic.xml
+```
+
 By default `agent-harness run` exits 0 on every successful run regardless of
 assertion outcomes — the result JSON is the source of truth. There are two
 ways to turn that into a job failure:
@@ -83,6 +93,8 @@ would need an HTTP agent server running before the harness step fires.
 Result JSON files are uploaded as a workflow artifact named
 `regression-results` after every run. The artifact upload step has
 `if: always()`, so you get the files whether the job passed or failed.
+If you write JUnit XML with `--junit-out`, include the XML files in the same
+artifact or pass them to your CI system's test-report publisher.
 
 To find them:
 

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 from agent_harness.adapters import DEFAULT_HTTP_TIMEOUT_SECONDS, AdapterError
+from agent_harness.junit import result_to_junit_xml
 from agent_harness.runner import (
     dry_run_scenario,
     run_scenario_live,
@@ -63,6 +64,10 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument(
         "--out",
         help="Optional path to write result JSON.",
+    )
+    run_parser.add_argument(
+        "--junit-out",
+        help="Optional path to write assertion results as JUnit XML.",
     )
     run_parser.add_argument(
         "--trace-file",
@@ -274,6 +279,9 @@ def main() -> int:
             Path(args.out).write_text(result_json + "\n", encoding="utf-8")
         else:
             print(result_json)
+
+        if args.junit_out:
+            Path(args.junit_out).write_text(result_to_junit_xml(result), encoding="utf-8")
 
         if args.exit_on_fail and result.result in {"fail", "error"}:
             return 1

--- a/src/agent_harness/junit.py
+++ b/src/agent_harness/junit.py
@@ -1,0 +1,51 @@
+"""JUnit XML rendering for harness results."""
+
+from __future__ import annotations
+
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+from agent_harness.result import AssertionResult, HarnessResult
+
+
+def result_to_junit_xml(result: HarnessResult) -> str:
+    """Render a harness result as a single JUnit testsuite."""
+    failures = sum(1 for assertion in result.assertions if assertion.result == "fail")
+    errors = sum(1 for assertion in result.assertions if assertion.result == "error")
+    skipped = sum(1 for assertion in result.assertions if assertion.result == "not_run")
+
+    testsuite = Element(
+        "testsuite",
+        {
+            "name": result.scenario_id,
+            "tests": str(len(result.assertions)),
+            "failures": str(failures),
+            "errors": str(errors),
+            "skipped": str(skipped),
+        },
+    )
+
+    for assertion in result.assertions:
+        testcase = SubElement(
+            testsuite,
+            "testcase",
+            {
+                "classname": result.scenario_id,
+                "name": assertion.id,
+            },
+        )
+        _append_assertion_status(testcase, assertion)
+
+    return tostring(testsuite, encoding="unicode") + "\n"
+
+
+def _append_assertion_status(testcase: Element, assertion: AssertionResult) -> None:
+    evidence = assertion.evidence or assertion.result
+    if assertion.result == "fail":
+        failure = SubElement(testcase, "failure", {"message": "assertion failed"})
+        failure.text = evidence
+    elif assertion.result == "error":
+        error = SubElement(testcase, "error", {"message": "assertion error"})
+        error.text = evidence
+    elif assertion.result == "not_run":
+        skipped = SubElement(testcase, "skipped", {"message": "assertion not run"})
+        skipped.text = evidence

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import xml.etree.ElementTree as ET
 
 import pytest
 
@@ -128,6 +129,50 @@ def test_run_dry_run_writes_result_file(capsys, monkeypatch, tmp_path):
     assert result["scenario_id"] == "goal_hijack.basic_001"
     assert result["mode"] == "dry_run"
     assert result["result"] == "not_run"
+
+
+def test_run_trace_file_writes_junit_xml(capsys, monkeypatch, tmp_path):
+    scenario_file, trace_file = _write_failing_trace_files(tmp_path)
+    junit_file = tmp_path / "result.xml"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-harness",
+            "run",
+            str(scenario_file),
+            "--trace-file",
+            str(trace_file),
+            "--junit-out",
+            str(junit_file),
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    testsuite = ET.fromstring(junit_file.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert result["result"] == "fail"
+    assert testsuite.tag == "testsuite"
+    assert testsuite.attrib["name"] == "goal_hijack.basic_001"
+    assert testsuite.attrib["tests"] == "1"
+    assert testsuite.attrib["failures"] == "1"
+    assert testsuite.attrib["errors"] == "0"
+    assert testsuite.attrib["skipped"] == "0"
+
+    testcase = testsuite.find("testcase")
+    assert testcase is not None
+    assert testcase.attrib["classname"] == "goal_hijack.basic_001"
+    assert testcase.attrib["name"] == "no_denied_tool_call"
+
+    failure = testcase.find("failure")
+    assert failure is not None
+    assert failure.attrib["message"] == "assertion failed"
+    assert "send_email" in (failure.text or "")
 
 
 def test_run_trace_file_fails_on_denied_tool_call(capsys, monkeypatch, tmp_path):

--- a/tests/test_junit.py
+++ b/tests/test_junit.py
@@ -1,0 +1,37 @@
+"""Tests for JUnit XML result output."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from agent_harness.junit import result_to_junit_xml
+from agent_harness.result import AssertionResult, HarnessResult
+
+
+def test_result_to_junit_xml_maps_assertion_statuses():
+    result = HarnessResult(
+        scenario_id="scenario.example",
+        mode="trace",
+        result="fail",
+        assertions=[
+            AssertionResult("passes", "pass", "ok"),
+            AssertionResult("fails", "fail", "bad tool call"),
+            AssertionResult("errors", "error", "adapter broke"),
+            AssertionResult("skips", "not_run", "not implemented"),
+        ],
+    )
+
+    testsuite = ET.fromstring(result_to_junit_xml(result))
+
+    assert testsuite.attrib["tests"] == "4"
+    assert testsuite.attrib["failures"] == "1"
+    assert testsuite.attrib["errors"] == "1"
+    assert testsuite.attrib["skipped"] == "1"
+
+    testcases = {case.attrib["name"]: case for case in testsuite.findall("testcase")}
+    assert testcases["passes"].find("failure") is None
+    assert testcases["passes"].find("error") is None
+    assert testcases["passes"].find("skipped") is None
+    assert testcases["fails"].find("failure").text == "bad tool call"
+    assert testcases["errors"].find("error").text == "adapter broke"
+    assert testcases["skips"].find("skipped").text == "not implemented"


### PR DESCRIPTION
Fixes #81.

## Summary

Adds JUnit XML output for `agent-harness run`, so CI systems that ingest test reports can consume assertion results without changing the existing result JSON flow.

## Changes

- Add a `--junit-out` CLI option for all run modes.
- Render one JUnit testcase per harness assertion.
- Map assertion statuses to JUnit report outcomes: pass stays clean, fail is a failure, error is an error, and not_run is skipped.
- Keep stdout and `--out` result JSON behavior unchanged.
- Document the option in the README and GitHub Actions CI guide.
- Add a CHANGELOG entry under Unreleased.

## Verification

```bash
python -m pytest tests/test_junit.py tests/test_cli.py tests/test_result_schema.py -q
ruff check src tests
mypy
python -m pytest -q
git diff --check
```

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code or documentation ?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance

**If you used AI assistance, briefly describe:**
- Tool(s) used: AI coding assistant.
- Parts of the contribution that were AI-assisted: CLI wiring, JUnit XML rendering, tests, and documentation drafting.
- How you reviewed the output: I reviewed the full diff, checked the CLI behavior against the existing result JSON flow, verified the XML status mapping, and confirmed the documentation matches the implemented option.
- Tests or checks I ran: The commands listed in the Verification section.

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every documentation, function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
- [x] I added an entry under `[Unreleased]` in `CHANGELOG.md` (or this PR does not need one - pure refactor, internal tests, or CI-only change)
