### PR TITLE
release: prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-07-27
+
+Hardening and CI ergonomics. This release makes the harness comfortable to run
+in real CI pipelines: machine-readable report formats (JUnit XML, SARIF),
+directory/suite execution, configurable live-HTTP behavior, adapter parity for
+goal events and LangGraph streaming, and a written schema-versioning policy.
+
 ### Added
 
 - **`suite` subcommand** — `agent-harness suite <paths...> --trace-dir <dir>`
@@ -153,5 +160,6 @@ a usable OWASP Incubator baseline.
   Windows junctions and reparse points, marker-file access, directory
   deletions, oversized reads, and non-UTF-8 reads.
 
-[Unreleased]: https://github.com/OWASP/Agent-Security-Regression-Harness/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/OWASP/Agent-Security-Regression-Harness/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/OWASP/Agent-Security-Regression-Harness/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/OWASP/Agent-Security-Regression-Harness/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ agent-harness version
 Expected output:
 
 ```text
-agent-harness 0.1.0
+agent-harness 0.2.0
 ```
 
 For authoring guidance, see [Scenario Specification](docs/scenario-spec.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "owasp-agent-security-regression-harness"
-version = "0.1.0"
+version = "0.2.0"
 description = "OWASP harness for executable security regression testing of agentic applications and MCP-integrated systems."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/agent_harness/__init__.py
+++ b/src/agent_harness/__init__.py
@@ -1,3 +1,3 @@
 """OWASP Agent Security Regression Harness."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/agent_harness/cli.py
+++ b/src/agent_harness/cli.py
@@ -26,7 +26,7 @@ from agent_harness.sarif import result_to_sarif
 from agent_harness.scenario import ScenarioValidationError, load_scenario
 from agent_harness.trace import TraceValidationError, load_trace
 
-VERSION = "0.1.0"
+VERSION = "0.2.0"
 HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
 
 


### PR DESCRIPTION
Release prep for **v0.2.0**, completing the "Hardening + CI ergonomics" milestone (11 issues closed, 0 open).

## Changes

- `CHANGELOG.md`: `[Unreleased]` → `[0.2.0] — 2026-07-27`, fresh empty `[Unreleased]`, updated compare links.
- Version bumped in all four locations required by `docs/releasing.md`: `pyproject.toml`, `src/agent_harness/__init__.py`, `src/agent_harness/cli.py`, `README.md`.

## What's in v0.2.0

| Area | Feature | Issue |
|---|---|---|
| CI reporting | JUnit XML output (`--junit-out`) | #81 |
| CI reporting | SARIF 2.1.0 output (`--sarif-out`) | #82 |
| Execution | `suite` subcommand for scenario + trace directories | #85 |
| Execution | Batch `validate` for directories and globs | #84 |
| Live HTTP | Configurable timeout (`--target-timeout`) | #92 |
| Live HTTP | Request headers (`--target-header`) | #93 |
| MCP | stdio host exposed through the CLI | #142 |
| Adapters | OpenAI Agents goal events | #94 |
| Adapters | LangGraph update streams | #95 |
| Assertions | `approval_required` | #135 |
| Governance | Schema versioning + breaking-change policy | #121 |

Note: `schemas/scenario.schema.json` moves to `"version": 2` in this release — scenario `id` is now constrained to `[A-Za-z0-9._-]` because ids are used as filesystem path components by the suite runner. Per the pre-1.0 rule in `docs/schema-versioning.md`, the package major line does not move. All bundled scenarios already comply.

## Verification

`ruff`, `mypy`, and `pytest` green locally (378 passed, 2 skipped, **93.33%** coverage vs the 80% gate). `agent-harness version` prints `0.2.0`.

After merge: tag `v0.2.0` on the merge commit to trigger `release.yml` (verify → build → publish-pypi → github-release). The `pypi` environment requires maintainer approval before publishing.