### PR TITLE
feat: add Streamable HTTP transport to MCP host

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,51 @@ jobs:
           name: coverage-report
           path: htmlcov/
 
+  mcp-sdk-compatibility:
+    name: MCP SDK compatibility (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: minimum
+            mcp_spec: "mcp==1.12.4"
+            expected_api: "legacy"
+          - name: latest-v1
+            mcp_spec: "mcp>=1.12.4,<2"
+            expected_api: "modern"
+    env:
+      EXPECTED_MCP_HTTP_API: ${{ matrix.expected_api }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install harness
+        run: python -m pip install -e ".[dev]"
+      - name: Install MCP SDK boundary
+        run: python -m pip install --upgrade "${{ matrix.mcp_spec }}"
+      - name: Check installed dependencies
+        run: python -m pip check
+      - name: Show compatibility versions
+        run: |
+          python - <<'PY'
+          import importlib.metadata
+          import platform
+
+          print(f"Python {platform.python_version()}")
+          print(f"MCP {importlib.metadata.version('mcp')}")
+          print(f"HTTPX {importlib.metadata.version('httpx')}")
+          PY
+      - name: Run MCP compatibility tests
+        run: |
+          python -m pytest \
+            tests/test_mcp_sdk_compat.py \
+            tests/test_mcp_host.py \
+            tests/test_mcp_runtime.py
+
   security-regression:
     name: Run security regression scenarios
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP Streamable HTTP transport** — add `transport: streamable_http` server
+  entries with a required `url` and optional static `headers` to the MCP host
+  runtime alongside the existing stdio transport.
+
 ## [0.2.0] — 2026-07-27
 
 Hardening and CI ergonomics. This release makes the harness comfortable to run

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -681,11 +681,16 @@ payload as the user message. If the target returns `assistant_message` or
 
 ### MCP host adapter
 
-The MCP host adapter runs a deterministic local Python target with a real MCP
-host context. Unlike `--mcp-target`, which accepts a workflow callable that
-reports already-observed MCP activity, `--mcp-host-target` starts configured
-stdio MCP servers and captures host-owned MCP evidence while the target calls
-tools through the host.
+The two MCP execution flags serve different purposes:
+
+- `--mcp-target` executes an MCP workflow callable that reports activity the
+  workflow has already observed. It does not start servers or act as the real
+  host.
+- `--mcp-host-target` loads a local target callable and executes it through the
+  real MCP host runtime. The runtime connects the configured `stdio` and
+  `streamable_http` servers and captures host-owned MCP evidence.
+- `--mcp-runtime-config` supplies the server configuration consumed by
+  `--mcp-host-target`; it does not apply to `--mcp-target`.
 
 Use `--mcp-host-target` when the target callable needs this two-argument
 contract:
@@ -709,8 +714,9 @@ adapters, plus an `MCPHostContext`. Synchronous targets call
 `host.call_tool(...)`. Async targets should use `await host.async_call_tool(...)`.
 
 Runtime server details are supplied by a separate YAML file, not by the
-scenario. This keeps portable scenario policy separate from local commands,
-paths, environment values, working directories, and timeouts.
+scenario. This keeps portable scenario policy separate from transport URLs,
+static headers, local commands, paths, environment values, working directories,
+and timeouts.
 
 Scenario example:
 
@@ -736,7 +742,7 @@ assertions:
   - type: no_denied_tool_call
 ```
 
-Runtime config example:
+`stdio` runtime configuration example:
 
 ```yaml
 servers:
@@ -750,25 +756,79 @@ servers:
     timeout_seconds: 5
 ```
 
+The example uses the repository's deterministic filesystem fixture. For a
+local fixture run, `MCP_FILESYSTEM_ROOT` must name an existing directory that
+contains the fixture marker file `.mcp_fixture_root`.
+
+Streamable HTTP runtime configuration example:
+
+```yaml
+servers:
+  - id: remote_tools
+    transport: streamable_http
+    url: https://mcp.example.test/mcp
+    headers:
+      X-Client-Name: agent-harness
+    timeout_seconds: 30
+```
+
+Every server must declare `transport` explicitly; omitting it does not silently
+select `stdio`. A single `servers` list may contain both transports. Their
+transport-specific configuration is discriminated as follows:
+
+| Transport | Required | Optional | Rejected |
+| --- | --- | --- | --- |
+| `stdio` | `command` | `args`, `env`, `cwd`, `timeout_seconds` | `url`, `headers` |
+| `streamable_http` | `url` | `headers`, `timeout_seconds` | `command`, `args`, `env`, `cwd` |
+
+Transport-specific fields are rejected rather than silently ignored.
+`timeout_seconds` is the single per-server timeout used by transport and MCP
+host operations; when omitted, it defaults to 5 seconds.
+
+Streamable HTTP `headers` are optional static pass-through values. Custom
+headers such as `Authorization` or `X-Api-Key` are accepted, but the runtime
+does not provide OAuth, token refresh, authorization discovery, credential
+storage, or credential lifecycle management. Protocol-owned and HTTP framing
+headers cannot be overridden. Keep sensitive values outside committed
+configuration and supply them through an appropriate configuration-generation
+or secret-management workflow.
+
+Automatic redirects are not followed. Configure the final MCP endpoint URL
+directly; the host will not forward configured custom headers to a redirected
+origin or automatically correct endpoint path variants.
+
 CLI usage:
 
 ```bash
 agent-harness run scenarios/mcp_trust_boundary/untrusted_server_delete_file_001.yaml \
-  --mcp-host-target examples.targets.mcp_host_agent:run_agent \
+  --mcp-host-target your_package.mcp_agent:run_agent \
   --mcp-runtime-config ./mcp-runtime.yaml
 ```
 
-`--mcp-runtime-config` is required when using `--mcp-host-target`. It only
-applies to `--mcp-host-target`; the workflow adapter continues to use
-`--mcp-target` without starting servers.
+Here `your_package.mcp_agent:run_agent` is the user's host target and must
+implement the two-argument callable contract shown above.
 
 The host owns MCP evidence fields such as `mcp_servers`, `mcp_tool_calls`, and
 `mcp_events`. Host targets should return normal assistant output or trace-shaped
 non-MCP data; they should not forge MCP tool calls or MCP lifecycle events.
 
-This adapter section covers local stdio host execution only. Streamable HTTP
-transport, OAuth, resources, prompts, sampling, and default-deny roots are
-separate design phases.
+Both transports produce the same canonical `mcp_servers`, `mcp_tool_calls`, and
+`mcp_events` collections. A successful tool run records this lifecycle:
+
+```text
+mcp_connection_initialized
+mcp_tools_discovered
+mcp_tool_result
+mcp_connection_closed
+```
+
+For Streamable HTTP, the configured URL and header values are used to establish
+the connection but are not included in canonical MCP metadata or lifecycle
+events. Normal operational host failures surface as `AdapterError`.
+
+Configured SSE, OAuth and authenticated transport lifecycle, MCP resources,
+prompts, sampling, roots, and default-deny roots remain outside this adapter's
+current scope.
 
 ### HTTP adapter
 

--- a/docs/mcp-adapter-design.md
+++ b/docs/mcp-adapter-design.md
@@ -306,16 +306,16 @@ For `stdio` servers:
 For Streamable HTTP servers:
 
 - Require explicit server URLs from runtime configuration.
-- Record the URL origin, not credentials.
-- Send the negotiated MCP protocol version header after initialization.
-- Do not follow redirects to a different origin unless explicitly configured.
-- Keep authentication tokens scoped to the intended MCP server.
-- Do not pass through tokens issued for some other service as if they were MCP
-  server tokens.
+- Do not include configured URLs or header values in canonical trace metadata.
+- Do not follow automatic redirects; require the final endpoint URL.
+- Accept optional static headers while leaving OAuth, token refresh,
+  authorization discovery, and credential lifecycle management out of scope.
+- Reject protocol-owned and HTTP framing headers rather than allowing runtime
+  configuration to override them.
 
 HTTP metadata discovery and OAuth flows can create SSRF and confused-deputy
-risks. The adapter should support allowlists for hosts, schemes, and redirect
-behavior before enabling remote MCP servers in tests.
+risks. Origin allowlists, OAuth flows, and broader SSRF policy remain separate
+future work rather than implicit behavior of the Streamable HTTP transport.
 
 ## Policy Mapping
 
@@ -392,8 +392,10 @@ HTTP coverage because stdio is easier to run deterministically in CI.
    tools, call tools through a deterministic fake target, and emit traces.
 4. Add resource and prompt tracing.
 5. Add default-deny handling for roots, sampling, and elicitation.
-6. Add Streamable HTTP support with origin allowlists and redacted auth
-   handling.
+6. Add Streamable HTTP transport plumbing with optional static headers, no
+   OAuth lifecycle, redirects disabled, and URL/header omission from trace
+   metadata. Implemented by issue #161; origin allowlists and OAuth remain
+   future work.
 7. Add MCP-specific assertions after trace conventions are stable.
 
 ## References

--- a/src/agent_harness/mcp_host.py
+++ b/src/agent_harness/mcp_host.py
@@ -12,11 +12,11 @@ import importlib
 import inspect
 import json
 import threading
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from contextlib import AsyncExitStack
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal, Protocol, cast
 
 from agent_harness.adapters import AdapterError
 from agent_harness.mcp_adapter import (
@@ -37,6 +37,8 @@ MCPHostTarget = Callable[
     [dict[str, Any], "MCPHostContext"],
     MCPHostTargetResult | Awaitable[MCPHostTargetResult],
 ]
+_StreamableHTTPClientCallable = Callable[..., Any]
+_HTTPXClientFactory = Callable[..., Any]
 
 DEFAULT_RESULT_CONTENT_LIMIT = 4096
 MAX_ERROR_MESSAGE_LENGTH = 512
@@ -70,6 +72,18 @@ class _MCPSDK:
     ClientSession: Any
     StdioServerParameters: Any
     stdio_client: Any
+    streamable_http_client: _StreamableHTTPClientCallable | None = None
+    streamablehttp_client: _StreamableHTTPClientCallable | None = None
+
+
+@dataclass(frozen=True)
+class _SelectedStreamableHTTPClient:
+    kind: Literal["modern", "legacy"]
+    client: _StreamableHTTPClientCallable
+
+
+class _IndexableTransportResult(Protocol):
+    def __getitem__(self, index: int, /) -> Any: ...
 
 
 @dataclass
@@ -186,6 +200,7 @@ class MCPHostContext:
                 timeout=connection.config.timeout_seconds,
             )
         except Exception as exc:
+            error_message = _mcp_tool_error_message(connection.config, exc)
             self._mcp_events.append(
                 {
                     "type": "mcp_tool_result",
@@ -193,13 +208,14 @@ class MCPHostContext:
                     "server_id": normalized_server_id,
                     "tool_name": normalized_tool_name,
                     "is_error": True,
-                    "error": _safe_error_message(exc),
+                    "error": error_message,
                 }
             )
-            raise AdapterError(
-                f"MCP tool call failed for {canonical_tool_name}: "
-                f"{_safe_error_message(exc)}"
-            ) from exc
+            message = f"MCP tool call failed for {canonical_tool_name}"
+            if connection.config.transport == "stdio":
+                message = f"{message}: {error_message}"
+                raise AdapterError(message) from exc
+            raise AdapterError(message) from None
 
         event = {
             "type": "mcp_tool_result",
@@ -274,48 +290,56 @@ async def async_run_mcp_host_target(
     payload = build_mcp_input(scenario)
     connections: dict[str, _MCPConnection] = {}
 
-    async with AsyncExitStack() as stack:
-        initial_events: list[dict[str, Any]] = []
+    try:
+        async with AsyncExitStack() as stack:
+            initial_events: list[dict[str, Any]] = []
 
-        for server_config in runtime_config.servers:
-            connection, events = await _connect_stdio_server(
-                server_config,
-                sdk,
-                stack,
+            for server_config in runtime_config.servers:
+                connection, events = await _connect_mcp_server(
+                    server_config,
+                    sdk,
+                    stack,
+                )
+                connections[server_config.id] = connection
+                initial_events.extend(events)
+
+            loop = asyncio.get_running_loop()
+            context = MCPHostContext(
+                connections,
+                loop=loop,
+                loop_thread_id=threading.get_ident(),
+                result_content_limit=result_content_limit,
             )
-            connections[server_config.id] = connection
-            initial_events.extend(events)
 
-        loop = asyncio.get_running_loop()
-        context = MCPHostContext(
-            connections,
-            loop=loop,
-            loop_thread_id=threading.get_ident(),
-            result_content_limit=result_content_limit,
-        )
+            for event in initial_events:
+                context._record_event(event)
 
-        for event in initial_events:
-            context._record_event(event)
+            try:
+                target_result = await _invoke_mcp_host_target(
+                    mcp_target,
+                    payload,
+                    context,
+                )
+            except AdapterError:
+                raise
+            except Exception as exc:
+                raise AdapterError(
+                    "MCP host target raised an exception: "
+                    f"{_safe_error_message(exc)}"
+                ) from exc
+            finally:
+                context._close()
 
-        try:
-            target_result = await _invoke_mcp_host_target(
-                mcp_target,
-                payload,
-                context,
+            mcp_servers = tuple(
+                deepcopy(connection.metadata) for connection in connections.values()
             )
-        except AdapterError:
+            mcp_tool_calls = context._snapshot_tool_calls()
+            mcp_events = context._snapshot_events()
+    except BaseExceptionGroup as exc:
+        adapter_error = _single_adapter_error_from_exception_group(exc)
+        if adapter_error is None:
             raise
-        except Exception as exc:
-            raise AdapterError(
-                "MCP host target raised an exception: "
-                f"{_safe_error_message(exc)}"
-            ) from exc
-        finally:
-            context._close()
-
-        mcp_servers = tuple(deepcopy(connection.metadata) for connection in connections.values())
-        mcp_tool_calls = context._snapshot_tool_calls()
-        mcp_events = context._snapshot_events()
+        raise adapter_error from None
 
     mcp_events = (
         *mcp_events,
@@ -343,6 +367,43 @@ async def async_run_mcp_host_target(
     )
 
 
+def _single_adapter_error_from_exception_group(
+    exception_group: BaseExceptionGroup[BaseException],
+) -> AdapterError | None:
+    adapter_errors: list[AdapterError] = []
+    pending: list[BaseException] = list(exception_group.exceptions)
+
+    while pending:
+        exception = pending.pop()
+        if isinstance(exception, BaseExceptionGroup):
+            pending.extend(exception.exceptions)
+        elif not isinstance(exception, Exception):
+            return None
+        elif isinstance(exception, AdapterError):
+            adapter_errors.append(exception)
+
+    if len(adapter_errors) == 1:
+        return adapter_errors[0]
+    return None
+
+
+async def _connect_mcp_server(
+    server_config: MCPServerConfig,
+    sdk: _MCPSDK,
+    stack: AsyncExitStack,
+) -> tuple[_MCPConnection, list[dict[str, Any]]]:
+    if server_config.transport == "stdio":
+        return await _connect_stdio_server(server_config, sdk, stack)
+
+    if server_config.transport == "streamable_http":
+        return await _connect_streamable_http_server(server_config, sdk, stack)
+
+    raise AdapterError(
+        f"MCP server {server_config.id} uses unsupported transport: "
+        f"{server_config.transport}"
+    )
+
+
 async def _connect_stdio_server(
     server_config: MCPServerConfig,
     sdk: _MCPSDK,
@@ -362,16 +423,12 @@ async def _connect_stdio_server(
             stack,
             server_params,
         )
-        session = await _open_client_session(
+        return await _connect_mcp_session(
             server_config,
             sdk,
             stack,
             read_stream,
             write_stream,
-        )
-        initialize_result, tools_result = await _initialize_session(
-            server_config,
-            session,
         )
     except AdapterError:
         raise
@@ -381,6 +438,50 @@ async def _connect_stdio_server(
             f"{server_config.id}: {_safe_error_message(exc)}"
         ) from exc
 
+
+async def _connect_streamable_http_server(
+    server_config: MCPServerConfig,
+    sdk: _MCPSDK,
+    stack: AsyncExitStack,
+) -> tuple[_MCPConnection, list[dict[str, Any]]]:
+    if server_config.transport != "streamable_http":
+        raise AdapterError(
+            f"MCP server {server_config.id} uses unsupported transport: "
+            f"{server_config.transport}"
+        )
+
+    read_stream, write_stream = await _open_streamable_http_transport(
+        server_config,
+        sdk,
+        stack,
+    )
+    return await _connect_mcp_session(
+        server_config,
+        sdk,
+        stack,
+        read_stream,
+        write_stream,
+    )
+
+
+async def _connect_mcp_session(
+    server_config: MCPServerConfig,
+    sdk: _MCPSDK,
+    stack: AsyncExitStack,
+    read_stream: Any,
+    write_stream: Any,
+) -> tuple[_MCPConnection, list[dict[str, Any]]]:
+    session = await _open_client_session(
+        server_config,
+        sdk,
+        stack,
+        read_stream,
+        write_stream,
+    )
+    initialize_result, tools_result = await _initialize_session(
+        server_config,
+        session,
+    )
     metadata = _server_metadata(server_config, initialize_result)
     tool_names = _tool_names_from_list_tools_result(tools_result)
     events = [
@@ -393,7 +494,7 @@ async def _connect_stdio_server(
 
 def _stdio_server_parameters(server_config: MCPServerConfig, sdk: _MCPSDK) -> Any:
     kwargs: dict[str, Any] = {
-        "command": server_config.command,
+        "command": _require_stdio_command(server_config),
         "args": list(server_config.args),
         "env": dict(server_config.env),
     }
@@ -423,6 +524,136 @@ async def _open_stdio_transport(
     )
 
 
+async def _open_streamable_http_transport(
+    server_config: MCPServerConfig,
+    sdk: _MCPSDK,
+    stack: AsyncExitStack,
+) -> tuple[Any, Any]:
+    try:
+        selected_client = _select_streamable_http_client(sdk)
+    except AdapterError:
+        raise AdapterError(
+            "The installed optional MCP SDK does not expose a usable "
+            f"Streamable HTTP client for MCP server {server_config.id}"
+        ) from None
+
+    httpx_module = _load_httpx_for_streamable_http(server_config.id)
+    if selected_client.kind == "modern":
+        transport_context = await _open_modern_streamable_http_context(
+            server_config,
+            selected_client.client,
+            httpx_module,
+            stack,
+        )
+    else:
+        transport_context = _open_legacy_streamable_http_context(
+            server_config,
+            selected_client.client,
+            httpx_module,
+        )
+
+    transport_result = await _wait_for_mcp_startup_step(
+        stack.enter_async_context(transport_context),
+        timeout_seconds=server_config.timeout_seconds,
+        server_id=server_config.id,
+        operation="open Streamable HTTP transport",
+        failure_message=(
+            "Could not open Streamable HTTP transport for MCP server "
+            f"{server_config.id}"
+        ),
+    )
+
+    try:
+        return _normalize_streamable_http_transport_result(transport_result)
+    except AdapterError:
+        raise AdapterError(
+            "Could not open Streamable HTTP transport for MCP server "
+            f"{server_config.id}: unexpected transport result"
+        ) from None
+
+
+async def _open_modern_streamable_http_context(
+    server_config: MCPServerConfig,
+    streamable_http_client: _StreamableHTTPClientCallable,
+    httpx_module: Any,
+    stack: AsyncExitStack,
+) -> Any:
+    try:
+        http_client_context = httpx_module.AsyncClient(
+            headers=dict(server_config.headers),
+            timeout=httpx_module.Timeout(server_config.timeout_seconds),
+            follow_redirects=False,
+        )
+    except Exception:
+        raise AdapterError(
+            "Could not create Streamable HTTP client for MCP server "
+            f"{server_config.id}"
+        ) from None
+
+    http_client = await _wait_for_mcp_startup_step(
+        stack.enter_async_context(http_client_context),
+        timeout_seconds=server_config.timeout_seconds,
+        server_id=server_config.id,
+        operation="open Streamable HTTP client",
+        failure_message=(
+            "Could not open Streamable HTTP client for MCP server "
+            f"{server_config.id}"
+        ),
+    )
+
+    try:
+        return streamable_http_client(
+            _require_streamable_http_url(server_config),
+            http_client=http_client,
+        )
+    except Exception:
+        raise AdapterError(
+            "Could not open Streamable HTTP transport for MCP server "
+            f"{server_config.id}"
+        ) from None
+
+
+def _open_legacy_streamable_http_context(
+    server_config: MCPServerConfig,
+    streamablehttp_client: _StreamableHTTPClientCallable,
+    httpx_module: Any,
+) -> Any:
+    try:
+        return streamablehttp_client(
+            _require_streamable_http_url(server_config),
+            headers=dict(server_config.headers),
+            timeout=server_config.timeout_seconds,
+            sse_read_timeout=server_config.timeout_seconds,
+            httpx_client_factory=_legacy_httpx_client_factory(httpx_module),
+        )
+    except Exception:
+        raise AdapterError(
+            "Could not open Streamable HTTP transport for MCP server "
+            f"{server_config.id}"
+        ) from None
+
+
+def _legacy_httpx_client_factory(
+    httpx_module: Any,
+) -> _HTTPXClientFactory:
+    def create_client(*args: Any, **kwargs: Any) -> Any:
+        client_kwargs = dict(kwargs)
+        client_kwargs["follow_redirects"] = False
+        return httpx_module.AsyncClient(*args, **client_kwargs)
+
+    return create_client
+
+
+def _load_httpx_for_streamable_http(server_id: str) -> Any:
+    try:
+        return importlib.import_module("httpx")
+    except ImportError:
+        raise AdapterError(
+            "HTTPX is unavailable while opening Streamable HTTP transport "
+            f"for MCP server {server_id}"
+        ) from None
+
+
 async def _open_client_session(
     server_config: MCPServerConfig,
     sdk: _MCPSDK,
@@ -430,11 +661,25 @@ async def _open_client_session(
     read_stream: Any,
     write_stream: Any,
 ) -> Any:
+    failure_message = None
+    if server_config.transport == "streamable_http":
+        failure_message = (
+            f"Could not open MCP client session for server {server_config.id}"
+        )
+
+    try:
+        session_context = sdk.ClientSession(read_stream, write_stream)
+    except Exception:
+        if failure_message is not None:
+            raise AdapterError(failure_message) from None
+        raise
+
     return await _wait_for_mcp_startup_step(
-        stack.enter_async_context(sdk.ClientSession(read_stream, write_stream)),
+        stack.enter_async_context(session_context),
         timeout_seconds=server_config.timeout_seconds,
         server_id=server_config.id,
         operation="open client session",
+        failure_message=failure_message,
     )
 
 
@@ -442,18 +687,31 @@ async def _initialize_session(
     server_config: MCPServerConfig,
     session: Any,
 ) -> tuple[Any, Any]:
+    initialize_failure_message = None
+    tools_failure_message = None
+    if server_config.transport == "streamable_http":
+        initialize_failure_message = (
+            f"Could not initialize MCP server {server_config.id}"
+        )
+        tools_failure_message = (
+            f"Could not discover tools for MCP server {server_config.id}"
+        )
+
     initialize_result = await _wait_for_mcp_startup_step(
         session.initialize(),
         timeout_seconds=server_config.timeout_seconds,
         server_id=server_config.id,
         operation="initialize session",
+        failure_message=initialize_failure_message,
     )
     tools_result = await _wait_for_mcp_startup_step(
         session.list_tools(),
         timeout_seconds=server_config.timeout_seconds,
         server_id=server_config.id,
         operation="list tools",
+        failure_message=tools_failure_message,
     )
+
     return initialize_result, tools_result
 
 
@@ -463,6 +721,7 @@ async def _wait_for_mcp_startup_step(
     timeout_seconds: float,
     server_id: str,
     operation: str,
+    failure_message: str | None = None,
 ) -> Any:
     try:
         return await asyncio.wait_for(awaitable, timeout=timeout_seconds)
@@ -470,6 +729,10 @@ async def _wait_for_mcp_startup_step(
         raise AdapterError(
             f"Timed out while trying to {operation} for MCP server {server_id}"
         ) from exc
+    except Exception:
+        if failure_message is not None:
+            raise AdapterError(failure_message) from None
+        raise
 
 
 def _callable_accepts_keyword(callable_object: Any, keyword: str) -> bool:
@@ -531,11 +794,85 @@ def _load_mcp_sdk(
     if stdio_server_parameters is None:
         stdio_server_parameters = stdio_module.StdioServerParameters
 
+    streamable_http_client, streamablehttp_client = (
+        _discover_streamable_http_clients(import_module)
+    )
+
     return _MCPSDK(
         ClientSession=client_session,
         StdioServerParameters=stdio_server_parameters,
         stdio_client=stdio_module.stdio_client,
+        streamable_http_client=streamable_http_client,
+        streamablehttp_client=streamablehttp_client,
     )
+
+
+def _discover_streamable_http_clients(
+    import_module: Callable[[str], Any],
+) -> tuple[
+    _StreamableHTTPClientCallable | None,
+    _StreamableHTTPClientCallable | None,
+]:
+    try:
+        streamable_http_module = import_module("mcp.client.streamable_http")
+    except ImportError:
+        return None, None
+
+    return (
+        _optional_sdk_callable(
+            getattr(streamable_http_module, "streamable_http_client", None)
+        ),
+        _optional_sdk_callable(
+            getattr(streamable_http_module, "streamablehttp_client", None)
+        ),
+    )
+
+
+def _optional_sdk_callable(value: Any) -> _StreamableHTTPClientCallable | None:
+    return value if callable(value) else None
+
+
+def _select_streamable_http_client(
+    sdk: _MCPSDK,
+) -> _SelectedStreamableHTTPClient:
+    if sdk.streamable_http_client is not None:
+        return _SelectedStreamableHTTPClient(
+            kind="modern",
+            client=sdk.streamable_http_client,
+        )
+
+    if sdk.streamablehttp_client is not None:
+        return _SelectedStreamableHTTPClient(
+            kind="legacy",
+            client=sdk.streamablehttp_client,
+        )
+
+    raise AdapterError(
+        "Installed MCP SDK does not expose a Streamable HTTP client"
+    )
+
+
+def _normalize_streamable_http_transport_result(
+    result: object,
+) -> tuple[Any, Any]:
+    error_message = (
+        "MCP SDK returned an unexpected Streamable HTTP transport result"
+    )
+
+    if isinstance(result, (str, bytes, bytearray, memoryview, Mapping)):
+        raise AdapterError(error_message)
+
+    indexable_result = cast(_IndexableTransportResult, result)
+    try:
+        read_stream = indexable_result[0]
+        write_stream = indexable_result[1]
+    except Exception:
+        raise AdapterError(error_message) from None
+
+    if read_stream is None or write_stream is None:
+        raise AdapterError(error_message)
+
+    return read_stream, write_stream
 
 
 def _validate_required_servers(
@@ -603,8 +940,8 @@ def _server_metadata(
     metadata = {
         "id": server_config.id,
         "transport": server_config.transport,
-        "command": _command_basename(server_config.command),
     }
+    metadata.update(_transport_metadata(server_config))
     metadata.update(_initialize_result_metadata(initialize_result))
     return metadata
 
@@ -618,20 +955,52 @@ def _connection_initialized_event(
         "id": server_config.id,
         "server_id": server_config.id,
         "transport": server_config.transport,
-        "command": _command_basename(server_config.command),
     }
+    event.update(_transport_metadata(server_config))
     event.update(_initialize_result_metadata(initialize_result))
     return event
 
 
 def _connection_closed_event(connection: _MCPConnection) -> dict[str, Any]:
-    return {
+    event = {
         "type": "mcp_connection_closed",
         "id": connection.config.id,
         "server_id": connection.config.id,
         "transport": connection.config.transport,
-        "command": _command_basename(connection.config.command),
     }
+    event.update(_transport_metadata(connection.config))
+    return event
+
+
+def _transport_metadata(server_config: MCPServerConfig) -> dict[str, Any]:
+    if server_config.transport == "stdio":
+        return {
+            "command": _command_basename(_require_stdio_command(server_config)),
+        }
+
+    if server_config.transport == "streamable_http":
+        return {}
+
+    raise AdapterError(
+        f"MCP server {server_config.id} uses unsupported transport: "
+        f"{server_config.transport}"
+    )
+
+
+def _require_stdio_command(server_config: MCPServerConfig) -> str:
+    if server_config.command is None:
+        raise AdapterError(
+            f"MCP stdio server {server_config.id} command is not configured"
+        )
+    return server_config.command
+
+
+def _require_streamable_http_url(server_config: MCPServerConfig) -> str:
+    if server_config.url is None:
+        raise AdapterError(
+            f"MCP Streamable HTTP server {server_config.id} URL is not configured"
+        )
+    return server_config.url
 
 
 def _command_basename(command: str) -> str:
@@ -1011,6 +1380,15 @@ def _truncate_jsonable(value: Any, *, limit: int) -> tuple[Any, bool]:
 def _safe_error_message(exc: Exception) -> str:
     message = str(exc) or exc.__class__.__name__
     return _truncate_string(message, MAX_ERROR_MESSAGE_LENGTH)
+
+
+def _mcp_tool_error_message(
+    server_config: MCPServerConfig,
+    exc: Exception,
+) -> str:
+    if server_config.transport == "streamable_http":
+        return "MCP Streamable HTTP tool call failed"
+    return _safe_error_message(exc)
 
 
 def _truncate_string(value: str, limit: int) -> str:

--- a/src/agent_harness/mcp_host.py
+++ b/src/agent_harness/mcp_host.py
@@ -724,7 +724,8 @@ async def _wait_for_mcp_startup_step(
     failure_message: str | None = None,
 ) -> Any:
     try:
-        return await asyncio.wait_for(awaitable, timeout=timeout_seconds)
+        async with asyncio.timeout(timeout_seconds):
+            return await awaitable
     except TimeoutError as exc:
         raise AdapterError(
             f"Timed out while trying to {operation} for MCP server {server_id}"

--- a/src/agent_harness/mcp_runtime.py
+++ b/src/agent_harness/mcp_runtime.py
@@ -8,17 +8,35 @@ MCP SDK dependency optional and lazily imported.
 from __future__ import annotations
 
 import importlib
+import re
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import yaml
 
 from agent_harness.adapters import AdapterError
 
 DEFAULT_MCP_TIMEOUT_SECONDS = 5.0
-SUPPORTED_MCP_TRANSPORTS = frozenset({"stdio"})
+SUPPORTED_MCP_TRANSPORTS = frozenset({"stdio", "streamable_http"})
+_HTTP_HEADER_NAME_PATTERN = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_RESERVED_MCP_HTTP_HEADERS = frozenset(
+    {
+        "accept",
+        "connection",
+        "content-length",
+        "content-type",
+        "host",
+        "last-event-id",
+        "mcp-protocol-version",
+        "mcp-session-id",
+        "transfer-encoding",
+    }
+)
+_STDIO_ONLY_FIELDS = ("command", "args", "env", "cwd")
+_STREAMABLE_HTTP_ONLY_FIELDS = ("url", "headers")
 MCP_INSTALL_HINT = (
     "MCP adapter dependencies are not installed. "
     'Install them with: python -m pip install '
@@ -32,11 +50,13 @@ class MCPServerConfig:
 
     id: str
     transport: str
-    command: str
+    command: str | None
     args: tuple[str, ...] = ()
     env: tuple[tuple[str, str], ...] = ()
     cwd: Path | None = None
     timeout_seconds: float = DEFAULT_MCP_TIMEOUT_SECONDS
+    url: str | None = field(default=None, repr=False)
+    headers: tuple[tuple[str, str], ...] = field(default=(), repr=False)
 
 
 @dataclass(frozen=True)
@@ -161,10 +181,24 @@ def _parse_server_config(
     label = _server_label(index)
     server_id = _server_id_from_entry(index, entry)
     transport = _parse_transport(label, entry)
-    command = _parse_stdio_command(label, entry, transport)
-    args = _parse_args(label, entry)
-    env = _parse_env(label, entry)
-    cwd = _parse_cwd(label, entry)
+    _validate_transport_fields(label, entry, transport)
+
+    command: str | None = None
+    args: tuple[str, ...] = ()
+    env: tuple[tuple[str, str], ...] = ()
+    cwd: Path | None = None
+    url: str | None = None
+    headers: tuple[tuple[str, str], ...] = ()
+
+    if transport == "stdio":
+        command = _parse_stdio_command(label, entry)
+        args = _parse_args(label, entry)
+        env = _parse_env(label, entry)
+        cwd = _parse_cwd(label, entry)
+    else:
+        url = _parse_streamable_http_url(label, entry)
+        headers = _parse_headers(label, entry)
+
     timeout_seconds = _parse_timeout_seconds(label, entry)
 
     return MCPServerConfig(
@@ -175,6 +209,8 @@ def _parse_server_config(
         env=env,
         cwd=cwd,
         timeout_seconds=timeout_seconds,
+        url=url,
+        headers=headers,
     )
 
 
@@ -218,14 +254,7 @@ def _parse_transport(label: str, entry: dict[str, Any]) -> str:
     return transport
 
 
-def _parse_stdio_command(
-    label: str,
-    entry: dict[str, Any],
-    transport: str,
-) -> str:
-    if transport != "stdio":
-        raise AdapterError(f"{label} transport is not implemented: {transport}")
-
+def _parse_stdio_command(label: str, entry: dict[str, Any]) -> str:
     command = entry.get("command")
     if not isinstance(command, str) or not command.strip():
         raise AdapterError(f"{label} command must be a non-empty string")
@@ -278,6 +307,100 @@ def _parse_cwd(label: str, entry: dict[str, Any]) -> Path | None:
         raise AdapterError(f"{label} cwd must be a non-empty string")
 
     return Path(cwd.strip())
+
+
+def _validate_transport_fields(
+    label: str,
+    entry: dict[str, Any],
+    transport: str,
+) -> None:
+    forbidden_fields = (
+        _STREAMABLE_HTTP_ONLY_FIELDS
+        if transport == "stdio"
+        else _STDIO_ONLY_FIELDS
+    )
+
+    for field_name in forbidden_fields:
+        if field_name in entry:
+            raise AdapterError(
+                f"{label} field {field_name!r} is not allowed for "
+                f"transport {transport!r}"
+            )
+
+
+def _parse_streamable_http_url(label: str, entry: dict[str, Any]) -> str:
+    url = entry.get("url")
+    if not isinstance(url, str) or not url.strip():
+        raise AdapterError(f"{label} url must be a non-empty string")
+
+    if "\\" in url:
+        raise AdapterError(f"{label} url must not contain backslashes")
+
+    if " " in url:
+        raise AdapterError(f"{label} url must not contain spaces")
+
+    if any(ord(character) < 32 or ord(character) == 127 for character in url):
+        raise AdapterError(f"{label} url must not contain ASCII control characters")
+
+    try:
+        parsed = urlsplit(url)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError as exc:
+        raise AdapterError(f"{label} url is invalid") from exc
+
+    if parsed.scheme not in {"http", "https"}:
+        raise AdapterError(f"{label} url scheme must be http or https")
+
+    if hostname is None:
+        raise AdapterError(f"{label} url must include a host")
+
+    if parsed.username is not None or parsed.password is not None:
+        raise AdapterError(f"{label} url must not include credentials")
+
+    if "#" in url:
+        raise AdapterError(f"{label} url must not include a fragment")
+
+    return url
+
+
+def _parse_headers(
+    label: str,
+    entry: dict[str, Any],
+) -> tuple[tuple[str, str], ...]:
+    headers = entry.get("headers", {})
+    if not isinstance(headers, dict):
+        raise AdapterError(f"{label} headers must be an object")
+
+    normalized_headers: list[tuple[str, str]] = []
+    seen_names: set[str] = set()
+
+    for name, value in headers.items():
+        if not isinstance(name, str):
+            raise AdapterError(f"{label} header names must be strings")
+        if not name:
+            raise AdapterError(f"{label} header names must be non-empty strings")
+        if _HTTP_HEADER_NAME_PATTERN.fullmatch(name) is None:
+            raise AdapterError(f"{label} header name is invalid: {name!r}")
+
+        normalized_name = name.casefold()
+        if normalized_name in seen_names:
+            raise AdapterError(f"{label} contains duplicate header name: {name!r}")
+        if normalized_name in _RESERVED_MCP_HTTP_HEADERS:
+            raise AdapterError(f"{label} header {name!r} is reserved")
+
+        if not isinstance(value, str):
+            raise AdapterError(f"{label} header {name!r} value must be a string")
+        if any(ord(character) < 32 or ord(character) == 127 for character in value):
+            raise AdapterError(
+                f"{label} header {name!r} value must not contain "
+                "ASCII control characters"
+            )
+
+        seen_names.add(normalized_name)
+        normalized_headers.append((name, value))
+
+    return tuple(normalized_headers)
 
 
 def _parse_timeout_seconds(label: str, entry: dict[str, Any]) -> float:

--- a/src/agent_harness/runner.py
+++ b/src/agent_harness/runner.py
@@ -164,7 +164,7 @@ def run_scenario_with_mcp_host_target(
     mcp_host_target: str,
     runtime_config_path: str,
 ) -> HarnessResult:
-    """Run a scenario against a local target through the MCP stdio host."""
+    """Run a scenario against a local target through the MCP host runtime."""
     from agent_harness import mcp_host, mcp_runtime
 
     target_callable = cast("MCPHostTarget", load_python_callable(mcp_host_target))

--- a/tests/fixtures/mcp_servers/filesystem_server.py
+++ b/tests/fixtures/mcp_servers/filesystem_server.py
@@ -11,7 +11,7 @@ import os
 import stat
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, get_type_hints
 
 ROOT_ENV_VAR = "MCP_FILESYSTEM_ROOT"
 ROOT_MARKER_FILE = ".mcp_fixture_root"
@@ -182,15 +182,18 @@ def create_server(root: str | Path | None = None) -> Any:
 
     mcp = FastMCP(SERVER_NAME)
 
-    @mcp.tool()
     def read_file(path: str) -> dict[str, Any]:
         """Read a UTF-8 text file from the fixture root."""
         return read_fixture_file(fixture_root, path)
 
-    @mcp.tool()
     def delete_file(path: str) -> dict[str, Any]:
         """Delete one regular file from the fixture root."""
         return delete_fixture_file(fixture_root, path)
+
+    read_file.__annotations__ = get_type_hints(read_file)
+    delete_file.__annotations__ = get_type_hints(delete_file)
+    mcp.tool()(read_file)
+    mcp.tool()(delete_file)
 
     return mcp
 

--- a/tests/test_mcp_host.py
+++ b/tests/test_mcp_host.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.metadata
 import importlib.util
 import subprocess
 import sys
+from contextlib import AsyncExitStack
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -242,6 +244,252 @@ def fake_sdk():
         ClientSession=FakeClientSession,
         StdioServerParameters=FakeStdioServerParameters,
         stdio_client=fake_stdio_client,
+    )
+
+
+def fake_sdk_with_http(*, modern=None, legacy=None):
+    return mcp_host._MCPSDK(
+        ClientSession=FakeClientSession,
+        StdioServerParameters=FakeStdioServerParameters,
+        stdio_client=fake_stdio_client,
+        streamable_http_client=modern,
+        streamablehttp_client=legacy,
+    )
+
+
+def make_http_runtime_config(
+    *,
+    server_id="filesystem_fixture",
+    url="https://mcp.example.test/service",
+    headers=None,
+    timeout_seconds=1,
+):
+    server = {
+        "id": server_id,
+        "transport": "streamable_http",
+        "url": url,
+        "timeout_seconds": timeout_seconds,
+    }
+    if headers is not None:
+        server["headers"] = headers
+    return parse_mcp_runtime_config({"servers": [server]})
+
+
+class FakeHTTPTimeout:
+    def __init__(self, timeout):
+        self.timeout = timeout
+
+
+class FakeHTTPClient:
+    def __init__(self, rig, args, kwargs):
+        self.rig = rig
+        self.args = args
+        self.kwargs = kwargs
+        self.exit_count = 0
+
+    async def __aenter__(self):
+        self.rig.lifecycle.append("http_client_enter")
+        if self.rig.client_enter_error is not None:
+            raise self.rig.client_enter_error
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.exit_count += 1
+        self.rig.lifecycle.append("http_client_exit")
+        return False
+
+
+class FakeHTTPTransportContext:
+    def __init__(self, rig, kind, legacy_kwargs=None):
+        self.rig = rig
+        self.kind = kind
+        self.legacy_kwargs = legacy_kwargs
+        self.legacy_client = None
+        self.exit_count = 0
+
+    async def __aenter__(self):
+        if self.rig.transport_enter_delay:
+            await asyncio.sleep(self.rig.transport_enter_delay)
+
+        if self.kind == "legacy":
+            assert self.legacy_kwargs is not None
+            factory = self.legacy_kwargs["httpx_client_factory"]
+            self.legacy_client = factory(
+                headers=self.legacy_kwargs["headers"],
+                timeout=FakeHTTPTimeout(self.legacy_kwargs["timeout"]),
+                auth=self.rig.legacy_auth,
+            )
+            await self.legacy_client.__aenter__()
+
+        self.rig.lifecycle.append(f"{self.kind}_transport_enter")
+        if self.rig.transport_enter_error is not None:
+            if self.legacy_client is not None:
+                await self.legacy_client.__aexit__(
+                    type(self.rig.transport_enter_error),
+                    self.rig.transport_enter_error,
+                    None,
+                )
+            raise self.rig.transport_enter_error
+        return self.rig.transport_result
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.exit_count += 1
+        self.rig.lifecycle.append(f"{self.kind}_transport_exit")
+        if self.legacy_client is not None:
+            await self.legacy_client.__aexit__(exc_type, exc, traceback)
+        if self.rig.transport_exit_error_factory is not None:
+            raise self.rig.transport_exit_error_factory(exc)
+        return False
+
+
+class FakeHTTPClientSession:
+    def __init__(self, rig, read_stream, write_stream):
+        if rig.session_construct_error is not None:
+            raise rig.session_construct_error
+        self.rig = rig
+        self.read_stream = read_stream
+        self.write_stream = write_stream
+        self.exit_count = 0
+        rig.sessions.append(self)
+
+    async def __aenter__(self):
+        self.rig.lifecycle.append("session_enter")
+        if self.rig.session_enter_error is not None:
+            raise self.rig.session_enter_error
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.exit_count += 1
+        self.rig.lifecycle.append("session_exit")
+        return False
+
+    async def initialize(self):
+        self.rig.initialize_count += 1
+        self.rig.lifecycle.append("initialize")
+        if self.rig.initialize_error is not None:
+            raise self.rig.initialize_error
+        return FakeModel(
+            protocolVersion="2025-11-25",
+            serverInfo={
+                "name": "fixture-http",
+                "title": "Fixture HTTP",
+                "version": "0.2.0",
+            },
+            capabilities={"tools": {}},
+        )
+
+    async def list_tools(self):
+        self.rig.list_tools_count += 1
+        self.rig.lifecycle.append("list_tools")
+        if self.rig.list_tools_error is not None:
+            raise self.rig.list_tools_error
+        return FakeModel(tools=FakeBehavior.tools)
+
+    async def call_tool(self, name, arguments):
+        self.rig.call_tool_count += 1
+        self.rig.lifecycle.append("call_tool")
+        if self.rig.call_tool_error is not None:
+            raise self.rig.call_tool_error
+        return SimpleNamespace(
+            isError=False,
+            structuredContent={"deleted": arguments["path"]},
+            content=[FakeModel(type="text", text=f"deleted {arguments['path']}")],
+        )
+
+
+class FakeHTTPRig:
+    def __init__(self):
+        self.lifecycle = []
+        self.clients = []
+        self.sessions = []
+        self.modern_calls = []
+        self.legacy_calls = []
+        self.transport_contexts = []
+        self.initialize_count = 0
+        self.list_tools_count = 0
+        self.call_tool_count = 0
+        self.client_construct_error = None
+        self.client_enter_error = None
+        self.modern_call_error = None
+        self.legacy_call_error = None
+        self.transport_enter_error = None
+        self.transport_exit_error_factory = None
+        self.transport_enter_delay = 0
+        self.session_construct_error = None
+        self.session_enter_error = None
+        self.initialize_error = None
+        self.list_tools_error = None
+        self.call_tool_error = None
+        self.transport_result = (
+            "http-read-stream",
+            "http-write-stream",
+            "ignored-session-callback",
+        )
+        self.legacy_auth = object()
+        self.httpx_module = SimpleNamespace(
+            AsyncClient=self.create_http_client,
+            Timeout=FakeHTTPTimeout,
+        )
+
+    def create_http_client(self, *args, **kwargs):
+        if self.client_construct_error is not None:
+            raise self.client_construct_error
+        client = FakeHTTPClient(self, args, kwargs)
+        self.clients.append(client)
+        return client
+
+    def modern_client(self, url, **kwargs):
+        self.modern_calls.append((url, kwargs))
+        if self.modern_call_error is not None:
+            raise self.modern_call_error
+        context = FakeHTTPTransportContext(self, "modern")
+        self.transport_contexts.append(context)
+        return context
+
+    def legacy_client(self, url, **kwargs):
+        self.legacy_calls.append((url, kwargs))
+        if self.legacy_call_error is not None:
+            raise self.legacy_call_error
+        context = FakeHTTPTransportContext(self, "legacy", kwargs)
+        self.transport_contexts.append(context)
+        return context
+
+    def sdk(self, *, modern=True, legacy=False):
+        def session_factory(read, write):
+            return FakeHTTPClientSession(self, read, write)
+
+        return mcp_host._MCPSDK(
+            ClientSession=session_factory,
+            StdioServerParameters=FakeStdioServerParameters,
+            stdio_client=fake_stdio_client,
+            streamable_http_client=self.modern_client if modern else None,
+            streamablehttp_client=self.legacy_client if legacy else None,
+        )
+
+
+def run_http_target(monkeypatch, rig, *, modern=True, legacy=False, target=None, config=None):
+    monkeypatch.setattr(
+        mcp_host,
+        "_load_httpx_for_streamable_http",
+        lambda server_id: rig.httpx_module,
+    )
+    scenario = make_mcp_scenario()
+    runtime_config = config or make_http_runtime_config()
+
+    if target is None:
+        def target(payload, host):
+            host.call_tool(
+                "filesystem_fixture",
+                "delete_file",
+                {"path": "notes.txt"},
+            )
+            return {"final_output": "Done."}
+
+    return run_mcp_host_target(
+        scenario,
+        target,
+        runtime_config,
+        sdk_loader=lambda: rig.sdk(modern=modern, legacy=legacy),
     )
 
 
@@ -1144,3 +1392,1187 @@ def test_load_mcp_sdk_raises_install_hint_when_optional_dependency_is_missing():
         mcp_host._load_mcp_sdk(import_module=missing_import)
 
     assert str(exc_info.value) == MCP_INSTALL_HINT
+
+
+def test_existing_fake_stdio_sdk_defaults_to_no_http_capabilities():
+    sdk = fake_sdk()
+
+    assert sdk.ClientSession is FakeClientSession
+    assert sdk.StdioServerParameters is FakeStdioServerParameters
+    assert sdk.stdio_client is fake_stdio_client
+    assert sdk.streamable_http_client is None
+    assert sdk.streamablehttp_client is None
+
+
+@pytest.mark.parametrize(
+    ("has_modern", "has_legacy"),
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+        (False, False),
+    ],
+)
+def test_sdk_representation_tracks_http_capabilities_independently(
+    has_modern,
+    has_legacy,
+):
+    modern = (lambda: None) if has_modern else None
+    legacy = (lambda: None) if has_legacy else None
+
+    sdk = fake_sdk_with_http(modern=modern, legacy=legacy)
+
+    assert (sdk.streamable_http_client is not None) is has_modern
+    assert (sdk.streamablehttp_client is not None) is has_legacy
+    assert sdk.stdio_client is fake_stdio_client
+
+
+def test_load_mcp_sdk_discovers_modern_and_legacy_symbols_independently():
+    def modern_client():
+        raise AssertionError("loader must not invoke the modern client")
+
+    def legacy_client():
+        raise AssertionError("loader must not invoke the legacy client")
+
+    modules = {
+        "mcp": SimpleNamespace(
+            ClientSession=FakeClientSession,
+            StdioServerParameters=FakeStdioServerParameters,
+        ),
+        "mcp.client.stdio": SimpleNamespace(
+            StdioServerParameters=FakeStdioServerParameters,
+            stdio_client=fake_stdio_client,
+        ),
+        "mcp.client.streamable_http": SimpleNamespace(
+            streamable_http_client=modern_client,
+            streamablehttp_client=legacy_client,
+        ),
+    }
+
+    sdk = mcp_host._load_mcp_sdk(import_module=modules.__getitem__)
+
+    assert sdk.streamable_http_client is modern_client
+    assert sdk.streamablehttp_client is legacy_client
+
+
+@pytest.mark.parametrize(
+    ("symbol_name", "expected_kind"),
+    [
+        ("streamable_http_client", "modern"),
+        ("streamablehttp_client", "legacy"),
+    ],
+)
+def test_load_mcp_sdk_discovers_each_http_symbol_when_exposed_alone(
+    symbol_name,
+    expected_kind,
+):
+    def available_client():
+        raise AssertionError("loader must not invoke the available client")
+
+    modules = {
+        "mcp": SimpleNamespace(
+            ClientSession=FakeClientSession,
+            StdioServerParameters=FakeStdioServerParameters,
+        ),
+        "mcp.client.stdio": SimpleNamespace(
+            StdioServerParameters=FakeStdioServerParameters,
+            stdio_client=fake_stdio_client,
+        ),
+        "mcp.client.streamable_http": SimpleNamespace(
+            **{symbol_name: available_client}
+        ),
+    }
+
+    sdk = mcp_host._load_mcp_sdk(import_module=modules.__getitem__)
+    selected = mcp_host._select_streamable_http_client(sdk)
+
+    assert selected.kind == expected_kind
+    assert selected.client is available_client
+
+
+def test_load_mcp_sdk_allows_streamable_module_without_client_symbols():
+    modules = {
+        "mcp": SimpleNamespace(
+            ClientSession=FakeClientSession,
+            StdioServerParameters=FakeStdioServerParameters,
+        ),
+        "mcp.client.stdio": SimpleNamespace(
+            StdioServerParameters=FakeStdioServerParameters,
+            stdio_client=fake_stdio_client,
+        ),
+        "mcp.client.streamable_http": SimpleNamespace(),
+    }
+
+    sdk = mcp_host._load_mcp_sdk(import_module=modules.__getitem__)
+
+    assert sdk.streamable_http_client is None
+    assert sdk.streamablehttp_client is None
+    assert sdk.stdio_client is fake_stdio_client
+
+
+def test_load_mcp_sdk_allows_missing_streamable_http_module():
+    modules = {
+        "mcp": SimpleNamespace(
+            ClientSession=FakeClientSession,
+            StdioServerParameters=FakeStdioServerParameters,
+        ),
+        "mcp.client.stdio": SimpleNamespace(
+            StdioServerParameters=FakeStdioServerParameters,
+            stdio_client=fake_stdio_client,
+        ),
+    }
+
+    def import_module(name):
+        try:
+            return modules[name]
+        except KeyError:
+            raise ModuleNotFoundError(f"No module named {name!r}", name=name) from None
+
+    sdk = mcp_host._load_mcp_sdk(import_module=import_module)
+
+    assert sdk.streamable_http_client is None
+    assert sdk.streamablehttp_client is None
+    assert sdk.stdio_client is fake_stdio_client
+
+
+def test_load_mcp_sdk_keeps_stdio_available_when_http_dependency_is_missing():
+    modules = {
+        "mcp": SimpleNamespace(
+            ClientSession=FakeClientSession,
+            StdioServerParameters=FakeStdioServerParameters,
+        ),
+        "mcp.client.stdio": SimpleNamespace(
+            StdioServerParameters=FakeStdioServerParameters,
+            stdio_client=fake_stdio_client,
+        ),
+    }
+
+    def import_module(name):
+        if name == "mcp.client.streamable_http":
+            raise ModuleNotFoundError("No module named 'httpx'", name="httpx")
+        return modules[name]
+
+    sdk = mcp_host._load_mcp_sdk(import_module=import_module)
+
+    assert sdk.streamable_http_client is None
+    assert sdk.streamablehttp_client is None
+    assert sdk.stdio_client is fake_stdio_client
+
+
+def test_load_mcp_sdk_ignores_non_callable_http_symbols():
+    modules = {
+        "mcp": SimpleNamespace(
+            ClientSession=FakeClientSession,
+            StdioServerParameters=FakeStdioServerParameters,
+        ),
+        "mcp.client.stdio": SimpleNamespace(
+            StdioServerParameters=FakeStdioServerParameters,
+            stdio_client=fake_stdio_client,
+        ),
+        "mcp.client.streamable_http": SimpleNamespace(
+            streamable_http_client="not-callable",
+            streamablehttp_client=object(),
+        ),
+    }
+
+    sdk = mcp_host._load_mcp_sdk(import_module=modules.__getitem__)
+
+    assert sdk.streamable_http_client is None
+    assert sdk.streamablehttp_client is None
+
+
+def test_importing_mcp_host_does_not_eagerly_import_httpx():
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import agent_harness.mcp_host; "
+            "print('httpx' in sys.modules)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout.strip() == "False"
+
+
+def test_select_streamable_http_client_prefers_modern_without_invoking_it():
+    calls = []
+
+    def modern_client():
+        calls.append("modern")
+
+    selected = mcp_host._select_streamable_http_client(
+        fake_sdk_with_http(modern=modern_client)
+    )
+
+    assert selected.kind == "modern"
+    assert selected.client is modern_client
+    assert calls == []
+
+
+def test_select_streamable_http_client_uses_legacy_when_modern_is_absent():
+    def legacy_client():
+        raise AssertionError("selection must not invoke the legacy client")
+
+    selected = mcp_host._select_streamable_http_client(
+        fake_sdk_with_http(legacy=legacy_client)
+    )
+
+    assert selected.kind == "legacy"
+    assert selected.client is legacy_client
+
+
+def test_select_streamable_http_client_modern_wins_when_both_exist():
+    def modern_client():
+        return None
+
+    def legacy_client():
+        return None
+
+    selected = mcp_host._select_streamable_http_client(
+        fake_sdk_with_http(modern=modern_client, legacy=legacy_client)
+    )
+
+    assert selected.kind == "modern"
+    assert selected.client is modern_client
+
+
+def test_select_streamable_http_client_does_not_inspect_package_version(
+    monkeypatch,
+):
+    def fail_version_lookup(distribution_name):
+        raise AssertionError(f"unexpected version lookup: {distribution_name}")
+
+    monkeypatch.setattr(importlib.metadata, "version", fail_version_lookup)
+
+    selected = mcp_host._select_streamable_http_client(
+        fake_sdk_with_http(modern=lambda: None)
+    )
+
+    assert selected.kind == "modern"
+
+
+def test_select_streamable_http_client_fails_only_when_capability_is_requested():
+    sdk = fake_sdk()
+
+    assert sdk.stdio_client is fake_stdio_client
+    with pytest.raises(
+        AdapterError,
+        match="Installed MCP SDK does not expose a Streamable HTTP client",
+    ):
+        mcp_host._select_streamable_http_client(sdk)
+
+
+def test_selected_modern_contract_does_not_operationally_fallback_to_legacy():
+    calls = []
+
+    def modern_client():
+        calls.append("modern")
+        raise TypeError("modern failure")
+
+    def legacy_client():
+        calls.append("legacy")
+
+    selected = mcp_host._select_streamable_http_client(
+        fake_sdk_with_http(modern=modern_client, legacy=legacy_client)
+    )
+
+    with pytest.raises(TypeError, match="modern failure"):
+        selected.client()
+
+    assert selected.kind == "modern"
+    assert calls == ["modern"]
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (("read", "write"), ("read", "write")),
+        (("read", "write", "session-id"), ("read", "write")),
+        (("read", "write", "session-id", "future"), ("read", "write")),
+    ],
+)
+def test_normalize_streamable_http_transport_result_accepts_two_or_more_items(
+    result,
+    expected,
+):
+    assert mcp_host._normalize_streamable_http_transport_result(result) == expected
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        (),
+        ("read",),
+        object(),
+        (item for item in ("read", "write")),
+        "read-write",
+        b"read-write",
+        {"0": "read", "1": "write"},
+        {0: "read", 1: "write"},
+        (None, "write"),
+        ("read", None),
+    ],
+)
+def test_normalize_streamable_http_transport_result_rejects_malformed_values(
+    result,
+):
+    with pytest.raises(
+        AdapterError,
+        match="unexpected Streamable HTTP transport result",
+    ):
+        mcp_host._normalize_streamable_http_transport_result(result)
+
+
+def test_invalid_transport_result_error_does_not_expose_raw_result_repr():
+    secret = "transport-result-secret"
+
+    class SensitiveMalformedResult:
+        def __getitem__(self, index):
+            raise TypeError(secret)
+
+        def __repr__(self):
+            return secret
+
+    with pytest.raises(AdapterError) as exc_info:
+        mcp_host._normalize_streamable_http_transport_result(
+            SensitiveMalformedResult()
+        )
+
+    assert secret not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+
+
+def test_connect_mcp_server_dispatches_exactly_one_connector(monkeypatch):
+    calls = []
+    sentinel = (object(), [])
+
+    async def connect_stdio(server_config, sdk, stack):
+        calls.append(("stdio", server_config.id))
+        return sentinel
+
+    async def connect_http(server_config, sdk, stack):
+        calls.append(("streamable_http", server_config.id))
+        return sentinel
+
+    monkeypatch.setattr(mcp_host, "_connect_stdio_server", connect_stdio)
+    monkeypatch.setattr(mcp_host, "_connect_streamable_http_server", connect_http)
+    stdio_config = make_runtime_config().servers[0]
+    http_config = make_http_runtime_config().servers[0]
+
+    async def dispatch():
+        async with AsyncExitStack() as stack:
+            assert await mcp_host._connect_mcp_server(
+                stdio_config,
+                fake_sdk(),
+                stack,
+            ) is sentinel
+            assert await mcp_host._connect_mcp_server(
+                http_config,
+                fake_sdk(),
+                stack,
+            ) is sentinel
+
+    asyncio.run(dispatch())
+
+    assert calls == [
+        ("stdio", "filesystem_fixture"),
+        ("streamable_http", "filesystem_fixture"),
+    ]
+
+
+def test_connect_mcp_server_rejects_unsupported_transport_without_config_repr():
+    server_config = mcp_host.MCPServerConfig(
+        id="unsupported_fixture",
+        transport="future_transport",
+        command=None,
+        url="https://secret.example.test/?token=hidden",
+        headers=(("X-Api-Key", "hidden"),),
+    )
+
+    async def dispatch():
+        async with AsyncExitStack() as stack:
+            await mcp_host._connect_mcp_server(server_config, fake_sdk(), stack)
+
+    with pytest.raises(AdapterError) as exc_info:
+        asyncio.run(dispatch())
+
+    message = str(exc_info.value)
+    assert "unsupported_fixture" in message
+    assert "future_transport" in message
+    assert "secret.example.test" not in message
+    assert "hidden" not in message
+
+
+def test_streamable_http_modern_path_has_canonical_trace_and_owned_cleanup(
+    monkeypatch,
+):
+    rig = FakeHTTPRig()
+    secret = "modern-secret"
+    url = "https://mcp.example.test/service?token=query-secret"
+    config = make_http_runtime_config(
+        url=url,
+        headers={
+            "Authorization": f"Bearer {secret}",
+            "X-Api-Key": secret,
+        },
+        timeout_seconds=2.5,
+    )
+
+    execution = run_http_target(
+        monkeypatch,
+        rig,
+        modern=True,
+        legacy=True,
+        config=config,
+    )
+
+    assert len(rig.clients) == 1
+    client = rig.clients[0]
+    assert client.kwargs["headers"] == {
+        "Authorization": f"Bearer {secret}",
+        "X-Api-Key": secret,
+    }
+    assert client.kwargs["timeout"].timeout == 2.5
+    assert client.kwargs["follow_redirects"] is False
+    assert rig.modern_calls == [(url, {"http_client": client})]
+    assert rig.legacy_calls == []
+    assert rig.sessions[0].read_stream == "http-read-stream"
+    assert rig.sessions[0].write_stream == "http-write-stream"
+    assert rig.initialize_count == 1
+    assert rig.list_tools_count == 1
+    assert rig.call_tool_count == 1
+    assert rig.lifecycle == [
+        "http_client_enter",
+        "modern_transport_enter",
+        "session_enter",
+        "initialize",
+        "list_tools",
+        "call_tool",
+        "session_exit",
+        "modern_transport_exit",
+        "http_client_exit",
+    ]
+    assert client.exit_count == 1
+    assert rig.transport_contexts[0].exit_count == 1
+    assert rig.sessions[0].exit_count == 1
+
+    server_metadata = execution.mcp_servers[0]
+    assert server_metadata == {
+        "id": "filesystem_fixture",
+        "transport": "streamable_http",
+        "protocol_version": "2025-11-25",
+        "server_name": "fixture-http",
+        "server_title": "Fixture HTTP",
+        "server_version": "0.2.0",
+        "capabilities": {"tools": {}},
+    }
+    assert execution.trace.tool_calls[0]["mcp_transport"] == "streamable_http"
+    initialized_event = execution.mcp_events[0]
+    assert initialized_event["server_id"] == "filesystem_fixture"
+    assert initialized_event["transport"] == "streamable_http"
+    assert initialized_event["protocol_version"] == "2025-11-25"
+    assert initialized_event["server_name"] == "fixture-http"
+    assert "command" not in initialized_event
+    assert [event["type"] for event in execution.mcp_events] == [
+        "mcp_connection_initialized",
+        "mcp_tools_discovered",
+        "mcp_tool_result",
+        "mcp_connection_closed",
+    ]
+    assert set(execution.workflow_result) >= {
+        "mcp_servers",
+        "mcp_tool_calls",
+        "mcp_events",
+    }
+    trace_text = str(execution.trace.to_dict())
+    assert url not in trace_text
+    assert "query-secret" not in trace_text
+    assert secret not in trace_text
+    assert "command" not in server_metadata
+    assert sum(
+        event["type"] == "mcp_connection_closed"
+        for event in execution.mcp_events
+    ) == 1
+
+
+def test_streamable_http_legacy_path_propagates_arguments_and_sdk_owns_client(
+    monkeypatch,
+):
+    rig = FakeHTTPRig()
+    url = "https://mcp.example.test/legacy"
+    headers = {"X-Api-Key": "legacy-secret"}
+    config = make_http_runtime_config(
+        url=url,
+        headers=headers,
+        timeout_seconds=3.25,
+    )
+
+    execution = run_http_target(
+        monkeypatch,
+        rig,
+        modern=False,
+        legacy=True,
+        config=config,
+    )
+
+    assert rig.modern_calls == []
+    assert len(rig.legacy_calls) == 1
+    called_url, called_kwargs = rig.legacy_calls[0]
+    assert called_url == url
+    assert set(called_kwargs) == {
+        "headers",
+        "timeout",
+        "sse_read_timeout",
+        "httpx_client_factory",
+    }
+    assert called_kwargs["headers"] == headers
+    assert called_kwargs["timeout"] == 3.25
+    assert called_kwargs["sse_read_timeout"] == 3.25
+    assert callable(called_kwargs["httpx_client_factory"])
+    assert len(rig.clients) == 1
+    internal_client = rig.clients[0]
+    assert internal_client.kwargs["headers"] == headers
+    assert internal_client.kwargs["timeout"].timeout == 3.25
+    assert internal_client.kwargs["auth"] is rig.legacy_auth
+    assert internal_client.kwargs["follow_redirects"] is False
+    assert rig.sessions[0].read_stream == "http-read-stream"
+    assert rig.sessions[0].write_stream == "http-write-stream"
+    assert rig.lifecycle == [
+        "http_client_enter",
+        "legacy_transport_enter",
+        "session_enter",
+        "initialize",
+        "list_tools",
+        "call_tool",
+        "session_exit",
+        "legacy_transport_exit",
+        "http_client_exit",
+    ]
+    assert internal_client.exit_count == 1
+    assert rig.transport_contexts[0].exit_count == 1
+    assert rig.sessions[0].exit_count == 1
+    assert execution.mcp_servers[0]["transport"] == "streamable_http"
+
+
+def test_legacy_httpx_factory_preserves_kwargs_without_mutating_caller_values():
+    rig = FakeHTTPRig()
+    headers = {"X-Api-Key": "secret"}
+    timeout = FakeHTTPTimeout(4)
+    auth = object()
+    kwargs = {
+        "headers": headers,
+        "timeout": timeout,
+        "auth": auth,
+        "follow_redirects": True,
+    }
+    original = dict(kwargs)
+
+    client = mcp_host._legacy_httpx_client_factory(rig.httpx_module)(**kwargs)
+
+    assert kwargs == original
+    assert client.kwargs == {
+        "headers": headers,
+        "timeout": timeout,
+        "auth": auth,
+        "follow_redirects": False,
+    }
+
+
+def test_http_capability_error_is_lazy_clear_and_secret_safe(monkeypatch):
+    config = make_http_runtime_config(
+        url="https://mcp.example.test/?token=query-secret",
+        headers={"X-Api-Key": "header-secret"},
+    )
+    httpx_loads = []
+
+    def unexpected_httpx_load(server_id):
+        httpx_loads.append(server_id)
+        raise AssertionError("HTTPX must not load without an MCP HTTP capability")
+
+    monkeypatch.setattr(
+        mcp_host,
+        "_load_httpx_for_streamable_http",
+        unexpected_httpx_load,
+    )
+
+    with pytest.raises(AdapterError) as exc_info:
+        run_mcp_host_target(
+            make_mcp_scenario(),
+            lambda payload, host: {"final_output": "unreachable"},
+            config,
+            sdk_loader=fake_sdk,
+        )
+
+    message = str(exc_info.value)
+    assert "usable Streamable HTTP client" in message
+    assert "filesystem_fixture" in message
+    assert "query-secret" not in message
+    assert "header-secret" not in message
+    assert httpx_loads == []
+
+
+def test_missing_httpx_affects_http_but_not_stdio_and_redacts_import_error(
+    monkeypatch,
+):
+    imports = []
+
+    def import_module(name):
+        imports.append(name)
+        raise ModuleNotFoundError(
+            "No module C:\\Users\\private\\httpx for https://secret.example",
+            name=name,
+        )
+
+    monkeypatch.setattr(mcp_host.importlib, "import_module", import_module)
+    run_mcp_host_target(
+        make_mcp_scenario(),
+        lambda payload, host: {"final_output": "stdio works"},
+        make_runtime_config(),
+        sdk_loader=fake_sdk,
+    )
+    assert imports == []
+
+    rig = FakeHTTPRig()
+    with pytest.raises(AdapterError) as exc_info:
+        run_mcp_host_target(
+            make_mcp_scenario(),
+            lambda payload, host: {"final_output": "unreachable"},
+            make_http_runtime_config(),
+            sdk_loader=lambda: rig.sdk(),
+        )
+
+    message = str(exc_info.value)
+    assert "HTTPX is unavailable" in message
+    assert "filesystem_fixture" in message
+    assert "C:\\Users\\private" not in message
+    assert "secret.example" not in message
+
+
+def test_broken_http_sdk_import_remains_optional_for_stdio():
+    modules = {
+        "mcp": SimpleNamespace(
+            ClientSession=FakeClientSession,
+            StdioServerParameters=FakeStdioServerParameters,
+        ),
+        "mcp.client.stdio": SimpleNamespace(
+            StdioServerParameters=FakeStdioServerParameters,
+            stdio_client=fake_stdio_client,
+        ),
+    }
+
+    def import_module(name):
+        if name == "mcp.client.streamable_http":
+            raise ImportError("failed in C:\\Users\\private\\http_transport.py")
+        return modules[name]
+
+    sdk = mcp_host._load_mcp_sdk(import_module=import_module)
+
+    assert sdk.stdio_client is fake_stdio_client
+    assert sdk.streamable_http_client is None
+    assert sdk.streamablehttp_client is None
+
+
+def test_modern_operational_failure_never_falls_back_and_redacts_http_details(
+    monkeypatch,
+):
+    rig = FakeHTTPRig()
+    rig.modern_call_error = RuntimeError(
+        "GET https://mcp.example.test/?token=query-secret "
+        "headers={'X-Api-Key': 'header-secret'} response=<Response [500]>"
+    )
+
+    with pytest.raises(AdapterError) as exc_info:
+        run_http_target(monkeypatch, rig, modern=True, legacy=True)
+
+    message = str(exc_info.value)
+    assert message == (
+        "Could not open Streamable HTTP transport for MCP server "
+        "filesystem_fixture"
+    )
+    assert rig.legacy_calls == []
+    assert rig.lifecycle == ["http_client_enter", "http_client_exit"]
+    assert rig.clients[0].exit_count == 1
+    assert exc_info.value.__cause__ is None
+
+
+@pytest.mark.parametrize(
+    ("stage", "expected_lifecycle"),
+    [
+        ("client_construct", []),
+        ("client_enter", ["http_client_enter"]),
+        ("transport_call", ["http_client_enter", "http_client_exit"]),
+        (
+            "transport_enter",
+            [
+                "http_client_enter",
+                "modern_transport_enter",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "normalize",
+            [
+                "http_client_enter",
+                "modern_transport_enter",
+                "modern_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "session_construct",
+            [
+                "http_client_enter",
+                "modern_transport_enter",
+                "modern_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "session_enter",
+            [
+                "http_client_enter",
+                "modern_transport_enter",
+                "session_enter",
+                "modern_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "initialize",
+            [
+                "http_client_enter",
+                "modern_transport_enter",
+                "session_enter",
+                "initialize",
+                "session_exit",
+                "modern_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "list_tools",
+            [
+                "http_client_enter",
+                "modern_transport_enter",
+                "session_enter",
+                "initialize",
+                "list_tools",
+                "session_exit",
+                "modern_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "call_tool",
+            [
+                "http_client_enter",
+                "modern_transport_enter",
+                "session_enter",
+                "initialize",
+                "list_tools",
+                "call_tool",
+                "session_exit",
+                "modern_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+    ],
+)
+def test_modern_partial_failures_unwind_each_entered_resource_once(
+    monkeypatch,
+    stage,
+    expected_lifecycle,
+):
+    rig = FakeHTTPRig()
+    secret_error = RuntimeError(
+        "https://secret.example/?token=hidden <Request secret-request>"
+    )
+    if stage == "normalize":
+        rig.transport_result = object()
+    elif stage == "transport_call":
+        rig.modern_call_error = secret_error
+    else:
+        setattr(rig, f"{stage}_error", secret_error)
+
+    with pytest.raises(AdapterError) as exc_info:
+        run_http_target(monkeypatch, rig)
+
+    assert rig.lifecycle == expected_lifecycle
+    assert "secret.example" not in str(exc_info.value)
+    assert "secret-request" not in str(exc_info.value)
+    assert all(client.exit_count <= 1 for client in rig.clients)
+    assert all(context.exit_count <= 1 for context in rig.transport_contexts)
+    assert all(session.exit_count <= 1 for session in rig.sessions)
+
+
+@pytest.mark.parametrize(
+    ("stage", "expected_lifecycle"),
+    [
+        ("legacy_call", []),
+        ("client_construct", []),
+        (
+            "transport_enter",
+            [
+                "http_client_enter",
+                "legacy_transport_enter",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "normalize",
+            [
+                "http_client_enter",
+                "legacy_transport_enter",
+                "legacy_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "session_construct",
+            [
+                "http_client_enter",
+                "legacy_transport_enter",
+                "legacy_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "session_enter",
+            [
+                "http_client_enter",
+                "legacy_transport_enter",
+                "session_enter",
+                "legacy_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "initialize",
+            [
+                "http_client_enter",
+                "legacy_transport_enter",
+                "session_enter",
+                "initialize",
+                "session_exit",
+                "legacy_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "list_tools",
+            [
+                "http_client_enter",
+                "legacy_transport_enter",
+                "session_enter",
+                "initialize",
+                "list_tools",
+                "session_exit",
+                "legacy_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+        (
+            "call_tool",
+            [
+                "http_client_enter",
+                "legacy_transport_enter",
+                "session_enter",
+                "initialize",
+                "list_tools",
+                "call_tool",
+                "session_exit",
+                "legacy_transport_exit",
+                "http_client_exit",
+            ],
+        ),
+    ],
+)
+def test_legacy_partial_failures_leave_client_sdk_owned_and_close_once(
+    monkeypatch,
+    stage,
+    expected_lifecycle,
+):
+    rig = FakeHTTPRig()
+    secret_error = RuntimeError("header-secret https://secret.example/query")
+    if stage == "normalize":
+        rig.transport_result = object()
+    else:
+        setattr(rig, f"{stage}_error", secret_error)
+
+    with pytest.raises(AdapterError) as exc_info:
+        run_http_target(monkeypatch, rig, modern=False, legacy=True)
+
+    assert rig.lifecycle == expected_lifecycle
+    assert "header-secret" not in str(exc_info.value)
+    assert "secret.example" not in str(exc_info.value)
+    assert all(client.exit_count <= 1 for client in rig.clients)
+    assert all(context.exit_count <= 1 for context in rig.transport_contexts)
+    assert all(session.exit_count <= 1 for session in rig.sessions)
+
+
+@pytest.mark.parametrize(
+    ("stage", "operation"),
+    [
+        ("session_construct", "open MCP client session"),
+        ("session_enter", "open MCP client session"),
+        ("initialize", "initialize MCP server"),
+        ("list_tools", "discover tools"),
+    ],
+)
+def test_http_session_errors_identify_operation_without_exposing_raw_exception(
+    monkeypatch,
+    stage,
+    operation,
+):
+    rig = FakeHTTPRig()
+    setattr(
+        rig,
+        f"{stage}_error",
+        RuntimeError(
+            "https://mcp.example.test/?secret=query "
+            "headers={'X-Api-Key': 'header-secret'}"
+        ),
+    )
+
+    with pytest.raises(AdapterError) as exc_info:
+        run_http_target(monkeypatch, rig)
+
+    message = str(exc_info.value)
+    assert operation in message
+    assert "filesystem_fixture" in message
+    assert "mcp.example.test" not in message
+    assert "header-secret" not in message
+
+
+def test_http_tool_error_uses_shared_event_path_but_redacts_transport_details(
+    monkeypatch,
+):
+    rig = FakeHTTPRig()
+    rig.call_tool_error = RuntimeError(
+        "POST https://mcp.example.test/?token=query-secret "
+        "headers={'X-Api-Key': 'header-secret'}"
+    )
+
+    def target(payload, host):
+        with pytest.raises(AdapterError) as exc_info:
+            host.call_tool(
+                "filesystem_fixture",
+                "delete_file",
+                {"path": "notes.txt"},
+            )
+        assert str(exc_info.value) == (
+            "MCP tool call failed for mcp/filesystem_fixture/delete_file"
+        )
+        assert exc_info.value.__cause__ is None
+        return {"final_output": "Handled."}
+
+    execution = run_http_target(monkeypatch, rig, target=target)
+    tool_result = [
+        event
+        for event in execution.mcp_events
+        if event["type"] == "mcp_tool_result"
+    ][0]
+
+    assert tool_result["is_error"] is True
+    assert tool_result["error"] == "MCP Streamable HTTP tool call failed"
+    assert tool_result["error"] != str(rig.call_tool_error)
+    assert [event["type"] for event in execution.mcp_events] == [
+        "mcp_connection_initialized",
+        "mcp_tools_discovered",
+        "mcp_tool_result",
+        "mcp_connection_closed",
+    ]
+    assert rig.lifecycle[-3:] == [
+        "session_exit",
+        "modern_transport_exit",
+        "http_client_exit",
+    ]
+
+
+def test_stdio_initialization_error_wording_remains_unchanged():
+    class FailingStdioSession(FakeClientSession):
+        async def initialize(self):
+            raise RuntimeError("stdio initialization detail")
+
+    sdk = mcp_host._MCPSDK(
+        ClientSession=FailingStdioSession,
+        StdioServerParameters=FakeStdioServerParameters,
+        stdio_client=fake_stdio_client,
+    )
+
+    with pytest.raises(AdapterError) as exc_info:
+        run_mcp_host_target(
+            make_mcp_scenario(),
+            lambda payload, host: {"final_output": "unreachable"},
+            make_runtime_config(),
+            sdk_loader=lambda: sdk,
+        )
+
+    assert str(exc_info.value) == (
+        "Could not initialize MCP server filesystem_fixture: "
+        "stdio initialization detail"
+    )
+
+
+def test_mixed_stdio_and_http_servers_use_one_dispatch_path_and_keep_identity(
+    monkeypatch,
+):
+    rig = FakeHTTPRig()
+    monkeypatch.setattr(
+        mcp_host,
+        "_load_httpx_for_streamable_http",
+        lambda server_id: rig.httpx_module,
+    )
+    config = parse_mcp_runtime_config(
+        {
+            "servers": [
+                {
+                    "id": "filesystem_fixture",
+                    "transport": "stdio",
+                    "command": "python",
+                },
+                {
+                    "id": "other_fixture",
+                    "transport": "streamable_http",
+                    "url": "https://mcp.example.test/service",
+                },
+            ]
+        }
+    )
+
+    def target(payload, host):
+        host.call_tool(
+            "filesystem_fixture",
+            "delete_file",
+            {"path": "stdio.txt"},
+        )
+        host.call_tool(
+            "other_fixture",
+            "delete_file",
+            {"path": "http.txt"},
+        )
+        return {"final_output": "Done."}
+
+    execution = run_mcp_host_target(
+        make_mcp_scenario(),
+        target,
+        config,
+        sdk_loader=lambda: rig.sdk(),
+    )
+
+    assert len(FAKE_STDIO_CONTEXTS) == 1
+    assert len(rig.modern_calls) == 1
+    assert [server["id"] for server in execution.mcp_servers] == [
+        "filesystem_fixture",
+        "other_fixture",
+    ]
+    assert [server["transport"] for server in execution.mcp_servers] == [
+        "stdio",
+        "streamable_http",
+    ]
+    assert [call["mcp_server_id"] for call in execution.trace.tool_calls] == [
+        "filesystem_fixture",
+        "other_fixture",
+    ]
+    assert [call["mcp_transport"] for call in execution.trace.tool_calls] == [
+        "stdio",
+        "streamable_http",
+    ]
+
+
+def test_streamable_http_transport_timeout_unwinds_modern_client(monkeypatch):
+    rig = FakeHTTPRig()
+    rig.transport_enter_delay = 0.05
+    config = make_http_runtime_config(timeout_seconds=0.01)
+
+    with pytest.raises(AdapterError, match="open Streamable HTTP transport"):
+        run_http_target(monkeypatch, rig, config=config)
+
+    assert rig.lifecycle == ["http_client_enter", "http_client_exit"]
+    assert rig.clients[0].exit_count == 1
+
+
+def test_streamable_http_cancellation_propagates_and_unwinds_entered_client(
+    monkeypatch,
+):
+    rig = FakeHTTPRig()
+    rig.transport_enter_delay = 10
+    monkeypatch.setattr(
+        mcp_host,
+        "_load_httpx_for_streamable_http",
+        lambda server_id: rig.httpx_module,
+    )
+
+    async def run_and_cancel():
+        task = asyncio.create_task(
+            async_run_mcp_host_target(
+                make_mcp_scenario(),
+                lambda payload, host: {"final_output": "unreachable"},
+                make_http_runtime_config(timeout_seconds=30),
+                sdk_loader=lambda: rig.sdk(),
+            )
+        )
+        while rig.lifecycle != ["http_client_enter"]:
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run_and_cancel())
+
+    assert rig.lifecycle == ["http_client_enter", "http_client_exit"]
+    assert rig.clients[0].exit_count == 1
+
+
+def test_http_cleanup_exception_group_preserves_single_safe_adapter_error(
+    monkeypatch,
+):
+    rig = FakeHTTPRig()
+    rig.initialize_error = RuntimeError(
+        "https://secret.example/?token=query-secret header-secret"
+    )
+
+    def group_cleanup_error(primary_error):
+        return ExceptionGroup(
+            "raw transport cleanup",
+            [
+                primary_error,
+                RuntimeError("cleanup-secret https://secret.example/cleanup"),
+            ],
+        )
+
+    rig.transport_exit_error_factory = group_cleanup_error
+
+    with pytest.raises(AdapterError) as exc_info:
+        run_http_target(monkeypatch, rig)
+
+    assert str(exc_info.value) == (
+        "Could not initialize MCP server filesystem_fixture"
+    )
+    assert exc_info.value.__cause__ is None
+    assert "query-secret" not in str(exc_info.value)
+    assert "header-secret" not in str(exc_info.value)
+    assert "cleanup-secret" not in str(exc_info.value)
+    assert rig.lifecycle[-3:] == [
+        "session_exit",
+        "modern_transport_exit",
+        "http_client_exit",
+    ]
+
+
+def test_exception_group_with_cancellation_is_not_converted_to_adapter_error():
+    exception_group = BaseExceptionGroup(
+        "cancellation during cleanup",
+        [
+            AdapterError("operation failed"),
+            asyncio.CancelledError(),
+        ],
+    )
+
+    assert (
+        mcp_host._single_adapter_error_from_exception_group(exception_group)
+        is None
+    )

--- a/tests/test_mcp_host.py
+++ b/tests/test_mcp_host.py
@@ -152,14 +152,18 @@ def reset_fake_mcp_behavior():
 class FakeStdioContext:
     def __init__(self, server_params):
         self.server_params = server_params
+        self.enter_task = None
+        self.exit_task = None
         self.exited = False
 
     async def __aenter__(self):
+        self.enter_task = asyncio.current_task()
         if FakeBehavior.stdio_enter_delay:
             await asyncio.sleep(FakeBehavior.stdio_enter_delay)
         return "read-stream", "write-stream"
 
     async def __aexit__(self, exc_type, exc, traceback):
+        self.exit_task = asyncio.current_task()
         self.exited = True
         return False
 
@@ -168,15 +172,19 @@ class FakeClientSession:
     def __init__(self, read_stream, write_stream):
         self.read_stream = read_stream
         self.write_stream = write_stream
+        self.enter_task = None
+        self.exit_task = None
         self.exited = False
         FAKE_CLIENT_SESSIONS.append(self)
 
     async def __aenter__(self):
+        self.enter_task = asyncio.current_task()
         if FakeBehavior.session_enter_delay:
             await asyncio.sleep(FakeBehavior.session_enter_delay)
         return self
 
     async def __aexit__(self, exc_type, exc, traceback):
+        self.exit_task = asyncio.current_task()
         self.exited = True
         return False
 
@@ -285,15 +293,19 @@ class FakeHTTPClient:
         self.rig = rig
         self.args = args
         self.kwargs = kwargs
+        self.enter_task = None
+        self.exit_task = None
         self.exit_count = 0
 
     async def __aenter__(self):
+        self.enter_task = asyncio.current_task()
         self.rig.lifecycle.append("http_client_enter")
         if self.rig.client_enter_error is not None:
             raise self.rig.client_enter_error
         return self
 
     async def __aexit__(self, exc_type, exc, traceback):
+        self.exit_task = asyncio.current_task()
         self.exit_count += 1
         self.rig.lifecycle.append("http_client_exit")
         return False
@@ -305,9 +317,12 @@ class FakeHTTPTransportContext:
         self.kind = kind
         self.legacy_kwargs = legacy_kwargs
         self.legacy_client = None
+        self.enter_task = None
+        self.exit_task = None
         self.exit_count = 0
 
     async def __aenter__(self):
+        self.enter_task = asyncio.current_task()
         if self.rig.transport_enter_delay:
             await asyncio.sleep(self.rig.transport_enter_delay)
 
@@ -333,6 +348,7 @@ class FakeHTTPTransportContext:
         return self.rig.transport_result
 
     async def __aexit__(self, exc_type, exc, traceback):
+        self.exit_task = asyncio.current_task()
         self.exit_count += 1
         self.rig.lifecycle.append(f"{self.kind}_transport_exit")
         if self.legacy_client is not None:
@@ -349,16 +365,20 @@ class FakeHTTPClientSession:
         self.rig = rig
         self.read_stream = read_stream
         self.write_stream = write_stream
+        self.enter_task = None
+        self.exit_task = None
         self.exit_count = 0
         rig.sessions.append(self)
 
     async def __aenter__(self):
+        self.enter_task = asyncio.current_task()
         self.rig.lifecycle.append("session_enter")
         if self.rig.session_enter_error is not None:
             raise self.rig.session_enter_error
         return self
 
     async def __aexit__(self, exc_type, exc, traceback):
+        self.exit_task = asyncio.current_task()
         self.exit_count += 1
         self.rig.lifecycle.append("session_exit")
         return False
@@ -850,6 +870,21 @@ def test_run_mcp_host_target_passes_host_context_and_records_real_tool_call():
     assert execution.trace.events[-1]["type"] == "mcp_connection_closed"
     assert FAKE_SERVER_PARAMS[0].env == {}
     assert FAKE_SERVER_PARAMS[0].cwd is None
+
+
+def test_stdio_contexts_open_and_close_in_the_same_task():
+    run_mcp_host_target(
+        make_mcp_scenario(),
+        lambda payload, host: {"final_output": "Done."},
+        make_runtime_config(),
+        sdk_loader=fake_sdk,
+    )
+
+    contexts = [
+        FAKE_STDIO_CONTEXTS[0],
+        FAKE_CLIENT_SESSIONS[0],
+    ]
+    assert all(context.enter_task is context.exit_task for context in contexts)
 
 
 def test_run_mcp_host_target_keeps_server_identity_for_same_tool_name():
@@ -1896,6 +1931,19 @@ def test_streamable_http_modern_path_has_canonical_trace_and_owned_cleanup(
         event["type"] == "mcp_connection_closed"
         for event in execution.mcp_events
     ) == 1
+
+
+def test_streamable_http_contexts_open_and_close_in_the_same_task(monkeypatch):
+    rig = FakeHTTPRig()
+
+    run_http_target(monkeypatch, rig)
+
+    contexts = [
+        rig.clients[0],
+        rig.transport_contexts[0],
+        rig.sessions[0],
+    ]
+    assert all(context.enter_task is context.exit_task for context in contexts)
 
 
 def test_streamable_http_legacy_path_propagates_arguments_and_sdk_owns_client(

--- a/tests/test_mcp_runtime.py
+++ b/tests/test_mcp_runtime.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -11,10 +13,16 @@ from agent_harness.mcp_runtime import (
     DEFAULT_MCP_TIMEOUT_SECONDS,
     MCP_INSTALL_HINT,
     MCPHostRuntime,
+    MCPServerConfig,
     ensure_mcp_sdk_available,
     load_mcp_runtime_config,
     parse_mcp_runtime_config,
 )
+
+
+def parse_single_server(server: dict[str, Any]) -> MCPServerConfig:
+    config = parse_mcp_runtime_config({"servers": [server]})
+    return config.get_server(server["id"])
 
 
 def test_load_mcp_runtime_config_accepts_valid_list_shape(tmp_path):
@@ -103,6 +111,417 @@ def test_parse_mcp_runtime_config_accepts_explicit_env_and_cwd():
     }
 
 
+def test_stdio_defaults_equality_and_positional_constructor_remain_compatible():
+    parsed_server = parse_single_server(
+        {
+            "id": "filesystem_fixture",
+            "transport": "stdio",
+            "command": "python",
+        }
+    )
+    expected_server = MCPServerConfig(
+        "filesystem_fixture",
+        "stdio",
+        "python",
+        (),
+        (),
+        None,
+        DEFAULT_MCP_TIMEOUT_SECONDS,
+    )
+
+    assert parsed_server == expected_server
+    assert parsed_server.url is None
+    assert parsed_server.headers == ()
+
+
+def test_parse_mcp_runtime_config_rejects_missing_transport():
+    with pytest.raises(AdapterError, match="transport must be a non-empty string"):
+        parse_mcp_runtime_config(
+            {
+                "servers": [
+                    {
+                        "id": "filesystem_fixture",
+                        "command": "python",
+                    }
+                ]
+            }
+        )
+
+
+def test_parse_streamable_http_accepts_url_only():
+    server = parse_single_server(
+        {
+            "id": "remote_fixture",
+            "transport": "streamable_http",
+            "url": "https://example.test/mcp",
+        }
+    )
+
+    assert server.transport == "streamable_http"
+    assert server.command is None
+    assert server.args == ()
+    assert server.env == ()
+    assert server.cwd is None
+    assert server.url == "https://example.test/mcp"
+    assert server.headers == ()
+    assert server.timeout_seconds == DEFAULT_MCP_TIMEOUT_SECONDS
+
+
+def test_parse_streamable_http_accepts_headers_and_timeout_in_declaration_order():
+    server = parse_single_server(
+        {
+            "id": "remote_fixture",
+            "transport": "streamable_http",
+            "url": "https://example.test/mcp",
+            "headers": {
+                "X-Client-Name": "agent-harness",
+                "X-Request-Mode": "regression",
+            },
+            "timeout_seconds": 30,
+        }
+    )
+
+    assert server.headers == (
+        ("X-Client-Name", "agent-harness"),
+        ("X-Request-Mode", "regression"),
+    )
+    assert server.timeout_seconds == 30.0
+
+
+def test_streamable_http_headers_are_immutable():
+    server = parse_single_server(
+        {
+            "id": "remote_fixture",
+            "transport": "streamable_http",
+            "url": "https://example.test/mcp",
+            "headers": {"X-Client-Name": "agent-harness"},
+        }
+    )
+
+    assert isinstance(server.headers, tuple)
+    with pytest.raises(FrozenInstanceError):
+        server.headers = ()  # type: ignore[misc]
+
+
+def test_streamable_http_repr_omits_url_and_headers():
+    config = parse_mcp_runtime_config(
+        {
+            "servers": [
+                {
+                    "id": "remote_fixture",
+                    "transport": "streamable_http",
+                    "url": "https://example.test/mcp?token=url-secret",
+                    "headers": {"X-Api-Key": "header-secret"},
+                }
+            ]
+        }
+    )
+
+    config_repr = repr(config)
+    assert "url=" not in config_repr
+    assert "headers=" not in config_repr
+    assert "url-secret" not in config_repr
+    assert "header-secret" not in config_repr
+
+
+def test_parse_streamable_http_requires_url():
+    with pytest.raises(AdapterError, match="url must be a non-empty string"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+            }
+        )
+
+
+@pytest.mark.parametrize("url", [None, "", " "])
+def test_parse_streamable_http_rejects_empty_url_values(url):
+    with pytest.raises(AdapterError, match="url must be a non-empty string"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": url,
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("url", "error"),
+    [
+        ("ftp://example.test/mcp", "url scheme must be http or https"),
+        ("https:///mcp", "url must include a host"),
+        ("https://user@example.test/mcp", "url must not include credentials"),
+        ("https://user:password@example.test/mcp", "url must not include credentials"),
+        ("https://example.test/mcp#tools", "url must not include a fragment"),
+        (r"https://example.test\mcp", "url must not contain backslashes"),
+        ("https://example .test/mcp", "url must not contain spaces"),
+        ("https://example.test:not-a-port/mcp", "url is invalid"),
+        ("https://example.test:65536/mcp", "url is invalid"),
+        ("https://[::1/mcp", "url is invalid"),
+    ],
+)
+def test_parse_streamable_http_rejects_invalid_urls(url, error):
+    with pytest.raises(AdapterError, match=error):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": url,
+            }
+        )
+
+
+@pytest.mark.parametrize("control", ["\x00", "\t", "\n", "\r", "\x1f", "\x7f"])
+def test_parse_streamable_http_rejects_url_ascii_controls(control):
+    with pytest.raises(AdapterError, match="url must not contain ASCII control"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": f"https://example.test/mcp{control}",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.test/mcp?mode=regression&limit=10",
+        "http://localhost:8000/mcp",
+        "http://192.168.1.25/mcp",
+        "http://[::1]:8000/mcp",
+    ],
+)
+def test_parse_streamable_http_accepts_supported_url_forms_without_rewriting(url):
+    server = parse_single_server(
+        {
+            "id": "remote_fixture",
+            "transport": "streamable_http",
+            "url": url,
+        }
+    )
+
+    assert server.url == url
+
+
+@pytest.mark.parametrize("headers", [None, [], "X-Test: value"])
+def test_parse_streamable_http_requires_headers_mapping(headers):
+    with pytest.raises(AdapterError, match="headers must be an object"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": "https://example.test/mcp",
+                "headers": headers,
+            }
+        )
+
+
+def test_parse_streamable_http_requires_string_header_names():
+    with pytest.raises(AdapterError, match="header names must be strings"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": "https://example.test/mcp",
+                "headers": {123: "value"},
+            }
+        )
+
+
+def test_parse_streamable_http_requires_string_header_values():
+    with pytest.raises(AdapterError, match="header 'X-Retry' value must be a string"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": "https://example.test/mcp",
+                "headers": {"X-Retry": 3},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["", "Bad Header", "Bad:Header", " Header", "X-Ünicode"],
+)
+def test_parse_streamable_http_rejects_invalid_header_names(name):
+    error = (
+        "header names must be non-empty strings"
+        if not name
+        else "header name is invalid"
+    )
+    with pytest.raises(AdapterError, match=error):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": "https://example.test/mcp",
+                "headers": {name: "value"},
+            }
+        )
+
+
+def test_parse_streamable_http_rejects_duplicate_header_names_case_insensitively():
+    with pytest.raises(AdapterError, match="duplicate header name"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": "https://example.test/mcp",
+                "headers": {
+                    "X-Client-Name": "first",
+                    "x-client-name": "second",
+                },
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Accept",
+        "content-TYPE",
+        "Mcp-Session-Id",
+        "mcp-protocol-version",
+        "Last-Event-ID",
+        "HOST",
+        "Content-Length",
+        "transfer-encoding",
+        "Connection",
+    ],
+)
+def test_parse_streamable_http_rejects_reserved_headers_case_insensitively(name):
+    with pytest.raises(AdapterError, match="header .* is reserved"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": "https://example.test/mcp",
+                "headers": {name: "reserved-value"},
+            }
+        )
+
+
+@pytest.mark.parametrize("control", ["\x00", "\t", "\n", "\r", "\x1f", "\x7f"])
+def test_parse_streamable_http_rejects_header_value_ascii_controls(control):
+    with pytest.raises(AdapterError, match="value must not contain ASCII control"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": "https://example.test/mcp",
+                "headers": {"X-Test": f"safe{control}secret"},
+            }
+        )
+
+
+def test_parse_streamable_http_accepts_static_authorization_and_custom_headers():
+    server = parse_single_server(
+        {
+            "id": "remote_fixture",
+            "transport": "streamable_http",
+            "url": "https://example.test/mcp",
+            "headers": {
+                "Authorization": "Bearer test-token",
+                "X-Api-Key": "test-key",
+                "X-Custom": "custom-value",
+            },
+        }
+    )
+
+    assert server.headers == (
+        ("Authorization", "Bearer test-token"),
+        ("X-Api-Key", "test-key"),
+        ("X-Custom", "custom-value"),
+    )
+
+
+@pytest.mark.parametrize(("field_name", "value"), [("url", None), ("headers", {})])
+def test_stdio_rejects_streamable_http_fields_by_presence(field_name, value):
+    with pytest.raises(AdapterError, match=f"field {field_name!r} is not allowed"):
+        parse_single_server(
+            {
+                "id": "filesystem_fixture",
+                "transport": "stdio",
+                "command": "python",
+                field_name: value,
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("command", ""),
+        ("command", None),
+        ("args", []),
+        ("args", None),
+        ("env", {}),
+        ("env", None),
+        ("cwd", ""),
+        ("cwd", None),
+    ],
+)
+def test_streamable_http_rejects_stdio_fields_by_presence(field_name, value):
+    with pytest.raises(AdapterError, match=f"field {field_name!r} is not allowed"):
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": "https://example.test/mcp",
+                field_name: value,
+            }
+        )
+
+
+def test_runtime_config_preserves_existing_unknown_field_policy():
+    server = parse_single_server(
+        {
+            "id": "filesystem_fixture",
+            "transport": "stdio",
+            "command": "python",
+            "unknown_future_field": "ignored",
+        }
+    )
+
+    assert server.command == "python"
+
+
+def test_header_validation_error_does_not_reveal_header_value():
+    secret = "header-secret"
+
+    with pytest.raises(AdapterError) as exc_info:
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": "https://example.test/mcp",
+                "headers": {"X-Api-Key": f"{secret}\n"},
+            }
+        )
+
+    assert secret not in str(exc_info.value)
+
+
+def test_url_validation_error_does_not_reveal_url_or_query():
+    secret = "query-secret"
+    url = f"https://example.test:not-a-port/mcp?token={secret}"
+
+    with pytest.raises(AdapterError) as exc_info:
+        parse_single_server(
+            {
+                "id": "remote_fixture",
+                "transport": "streamable_http",
+                "url": url,
+            }
+        )
+
+    assert url not in str(exc_info.value)
+    assert secret not in str(exc_info.value)
+
+
 def test_parse_mcp_runtime_config_rejects_empty_servers():
     with pytest.raises(AdapterError, match="at least one server"):
         parse_mcp_runtime_config({"servers": []})
@@ -159,13 +578,13 @@ def test_parse_mcp_runtime_config_rejects_duplicate_server_ids():
 
 
 def test_parse_mcp_runtime_config_rejects_unknown_transport():
-    with pytest.raises(AdapterError, match="transport 'streamable_http' is not supported"):
+    with pytest.raises(AdapterError, match="transport 'websocket' is not supported"):
         parse_mcp_runtime_config(
             {
                 "servers": [
                     {
                         "id": "filesystem_fixture",
-                        "transport": "streamable_http",
+                        "transport": "websocket",
                         "command": "python",
                     }
                 ]

--- a/tests/test_mcp_sdk_compat.py
+++ b/tests/test_mcp_sdk_compat.py
@@ -1,0 +1,182 @@
+"""Compatibility checks against the real installed MCP and HTTPX packages."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.metadata
+import importlib.util
+import os
+import socket
+from collections.abc import Callable, Generator
+from typing import Any
+
+import pytest
+
+if importlib.util.find_spec("mcp") is None:
+    pytest.skip(
+        "real MCP SDK is required for compatibility tests",
+        allow_module_level=True,
+    )
+
+import httpx
+
+from agent_harness import mcp_host
+
+_EXPECTED_API_ENV = "EXPECTED_MCP_HTTP_API"
+_SUPPORTED_EXPECTATIONS = frozenset({"legacy", "modern"})
+_CONSTRUCTION_URL = "https://example.invalid/mcp?compatibility-marker=issue161"
+_HEADER_NAME = "X-Issue161-Compatibility"
+_HEADER_VALUE = "compat-secret-marker"
+
+
+@pytest.fixture(autouse=True)
+def prevent_network_io(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    def blocked_socket_connection(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("compatibility tests must not open network connections")
+
+    async def blocked_http_send(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("compatibility tests must not send HTTP requests")
+
+    monkeypatch.setattr(socket, "create_connection", blocked_socket_connection)
+    monkeypatch.setattr(httpx.AsyncClient, "send", blocked_http_send)
+    yield
+
+
+@pytest.fixture(scope="module")
+def expected_api() -> str:
+    value = os.environ.get(_EXPECTED_API_ENV)
+    if value is None:
+        pytest.skip(
+            f"{_EXPECTED_API_ENV} is required for boundary-specific checks"
+        )
+    if value not in _SUPPORTED_EXPECTATIONS:
+        pytest.fail(
+            f"{_EXPECTED_API_ENV} must be one of "
+            f"{sorted(_SUPPORTED_EXPECTATIONS)}; got {value!r}"
+        )
+    return value
+
+
+def test_real_sdk_loader_preserves_stdio_and_selects_actual_http_callable() -> None:
+    sdk = mcp_host._load_mcp_sdk()
+    selected = mcp_host._select_streamable_http_client(sdk)
+    streamable_http_module = importlib.import_module("mcp.client.streamable_http")
+    selected_symbol = (
+        "streamable_http_client"
+        if selected.kind == "modern"
+        else "streamablehttp_client"
+    )
+
+    assert callable(sdk.ClientSession)
+    assert callable(sdk.StdioServerParameters)
+    assert callable(sdk.stdio_client)
+    assert selected.client is getattr(streamable_http_module, selected_symbol)
+    assert selected.client.__module__.startswith("mcp.")
+
+
+def test_real_selector_matches_explicit_matrix_expectation(
+    expected_api: str,
+) -> None:
+    sdk = mcp_host._load_mcp_sdk()
+    selected = mcp_host._select_streamable_http_client(sdk)
+    diagnostic = _version_diagnostic()
+
+    assert selected.kind == expected_api, (
+        f"{diagnostic}; expected {expected_api!r}, selected {selected.kind!r}"
+    )
+
+    if expected_api == "legacy":
+        assert sdk.streamablehttp_client is not None, diagnostic
+    else:
+        assert sdk.streamable_http_client is not None, diagnostic
+        assert selected.client is sdk.streamable_http_client
+
+
+def test_real_modern_invocation_accepts_production_argument_shape(
+    expected_api: str,
+) -> None:
+    if expected_api != "modern":
+        pytest.skip("modern invocation applies only to the latest-v1 boundary")
+
+    sdk = mcp_host._load_mcp_sdk()
+    selected = mcp_host._select_streamable_http_client(sdk)
+    client = httpx.AsyncClient(
+        headers={_HEADER_NAME: _HEADER_VALUE},
+        timeout=httpx.Timeout(1.25),
+        follow_redirects=False,
+    )
+
+    try:
+        transport_context = selected.client(
+            _CONSTRUCTION_URL,
+            http_client=client,
+        )
+        _assert_async_context_manager(transport_context)
+        assert client.follow_redirects is False
+        request = client.build_request("POST", "https://example.invalid/mcp")
+        if request.headers.get(_HEADER_NAME) != _HEADER_VALUE:
+            pytest.fail("modern client did not preserve the configured header")
+    finally:
+        asyncio.run(client.aclose())
+
+    assert client.is_closed
+
+
+def test_real_legacy_invocation_accepts_production_argument_shape(
+    expected_api: str,
+) -> None:
+    if expected_api != "legacy":
+        pytest.skip("legacy invocation applies only to the minimum boundary")
+
+    sdk = mcp_host._load_mcp_sdk()
+    selected = mcp_host._select_streamable_http_client(sdk)
+    factory = mcp_host._legacy_httpx_client_factory(httpx)
+    transport_context = selected.client(
+        _CONSTRUCTION_URL,
+        headers={_HEADER_NAME: _HEADER_VALUE},
+        timeout=1.25,
+        sse_read_timeout=1.25,
+        httpx_client_factory=factory,
+    )
+
+    _assert_async_context_manager(transport_context)
+
+
+def test_legacy_factory_uses_real_httpx_and_forces_redirects_off() -> None:
+    factory = mcp_host._legacy_httpx_client_factory(httpx)
+    auth = httpx.BasicAuth("compat-user", "compat-password")
+    client = factory(
+        headers={_HEADER_NAME: _HEADER_VALUE},
+        timeout=httpx.Timeout(1.25),
+        auth=auth,
+        follow_redirects=True,
+    )
+
+    try:
+        assert isinstance(client, httpx.AsyncClient)
+        assert client.follow_redirects is False
+        assert client.auth is auth
+        request = client.build_request("POST", "https://example.invalid/mcp")
+        if request.headers.get(_HEADER_NAME) != _HEADER_VALUE:
+            pytest.fail("legacy factory did not preserve the configured header")
+    finally:
+        asyncio.run(client.aclose())
+
+    assert client.is_closed
+
+
+def _assert_async_context_manager(value: Any) -> None:
+    enter = getattr(value, "__aenter__", None)
+    exit_ = getattr(value, "__aexit__", None)
+    assert isinstance(enter, Callable)
+    assert isinstance(exit_, Callable)
+
+
+def _version_diagnostic() -> str:
+    return (
+        f"Python package compatibility: MCP {importlib.metadata.version('mcp')}, "
+        f"HTTPX {importlib.metadata.version('httpx')}"
+    )


### PR DESCRIPTION
Fixes #161 

#### Describe the changes you have made in this PR -

This PR adds unauthenticated Streamable HTTP transport support to the real MCP host runtime, alongside the existing stdio transport.

I wanted to keep this change narrow and reviewable: the goal is not to redesign the MCP host, but to add a second transport that converges into the same session lifecycle, trace format, error model, and cleanup guarantees already used by stdio.

## Design approach

Before implementing the transport, I considered three possible approaches.

### Option A — Legacy API only

Use `streamablehttp_client`, which is available at the project’s minimum supported MCP SDK version (`1.12.4`).

This would have been the smallest implementation and would have covered the complete declared dependency range. However, it would also introduce a new feature using an API that is already deprecated in newer MCP v1 releases.

### Option B — Modern API only

Use the newer `streamable_http_client` API and a host-managed `httpx.AsyncClient`.

This provides the cleanest current API and clearer HTTP client ownership, but it is not available in MCP `1.12.4`. Choosing it exclusively would either break the project’s published compatibility range or require raising the minimum MCP version as part of this PR.

### Option C — Modern-first compatibility adapter

Prefer `streamable_http_client` when the installed SDK exposes it, and use `streamablehttp_client` only when the modern symbol is absent.

I chose this approach because it is the only one that satisfies both sides of the project’s current contract:

* It supports the declared `mcp>=1.12.4,<2` range.
* It uses the current SDK API whenever possible.
* It avoids version-string checks.
* It keeps the API differences isolated at the transport boundary.
* It provides a straightforward path to remove the legacy branch when the project eventually raises its minimum MCP version.

The fallback is based strictly on symbol availability. A failed modern connection is treated as a real operational failure and is never retried through the legacy API, since doing so could hide defects or duplicate connection side effects.

## Runtime configuration

The MCP runtime configuration now:

* Accepts `transport: streamable_http`.
* Requires an HTTP or HTTPS `url`.
* Accepts optional static `headers`.
* Preserves the existing per-server `timeout_seconds`.
* Supports stdio and Streamable HTTP servers in the same runtime configuration.
* Keeps `transport` explicit, preserving the parser’s existing behavior.
* Rejects transport-specific fields instead of accepting and silently ignoring them.

For example, stdio continues to require `command`, while Streamable HTTP requires `url` and rejects stdio-only fields such as `command`, `args`, `env`, and `cwd`.

The URL and configured headers are treated as potentially sensitive configuration and are excluded from the configuration representation.

## MCP SDK compatibility

The host now:

* Prefers the modern `streamable_http_client` API when available.
* Uses the legacy `streamablehttp_client` API only when the modern symbol is absent.
* Detects capabilities by symbol presence rather than package-version comparisons.
* Normalizes both SDK transport results into the same internal read/write stream contract.
* Passes those streams into the existing shared `ClientSession` lifecycle.
* Preserves stdio functionality when the optional HTTP SDK surface is missing or broken.
* Produces a clear HTTP-specific `AdapterError` only when Streamable HTTP is explicitly requested.

A focused Python 3.11 compatibility matrix validates both boundaries of the declared MCP v1 range:

* MCP `1.12.4`
* Latest stable MCP v1 allowed by `mcp>=1.12.4,<2`

## Transport ownership and lifecycle

Transport-specific behavior ends after obtaining the read and write streams.

From that point onward, both transports use the same flow:

`ClientSession` → initialize → discover tools → execute tool calls → close

For the modern API:

* The host creates and owns one `httpx.AsyncClient`.
* The HTTP client is entered before the MCP transport.
* The MCP transport is closed before the HTTP client.

For the legacy API:

* The legacy SDK transport owns its internal HTTP client.
* The host provides a small HTTPX factory to enforce the required redirect policy.
* The host does not create or close a duplicate outer HTTP client.

Partial failures during HTTP client creation, transport entry, stream normalization, session entry, initialization, tool discovery, and tool execution all unwind through the existing async resource stack.

## Host behavior and trace parity

The host now dispatches through a single transport boundary based on `server_config.transport`:

* `stdio` uses the existing stdio connector.
* `streamable_http` uses the new HTTP connector.
* Unsupported transports produce a defensive `AdapterError`.

Both transports produce the same canonical trace containers:

* `mcp_servers`
* `mcp_tool_calls`
* `mcp_events`

Successful runs preserve the existing lifecycle sequence:

`mcp_connection_initialized` → `mcp_tools_discovered` → `mcp_tool_result` → `mcp_connection_closed`

The existing stdio metadata remains unchanged. HTTP metadata uses the configured server ID and negotiated MCP server information without introducing an artificial command field or exposing the endpoint URL.

## Security and error handling

Several defensive decisions were applied deliberately:

* Automatic HTTP redirects are disabled in both SDK paths.
* Users must configure the final MCP endpoint URL.
* This prevents custom headers such as `X-Api-Key` from being forwarded to an unintended redirected origin.
* Protocol-owned and HTTP framing headers cannot be overridden through runtime configuration.
* URLs, query parameters, and configured header values are omitted from canonical MCP trace metadata.
* HTTP operational errors use bounded, operation-oriented `AdapterError` messages rather than interpolating raw HTTP exceptions.
* Stdio retains its existing error behavior.

Real MCP/AnyIO testing also revealed that cleanup could wrap an already-safe `AdapterError` inside an `ExceptionGroup`.

The host now unwraps that group only when its complete recursive leaf set contains exactly one unambiguous `AdapterError`.

It deliberately does not collapse:

* Mixed exception groups.
* Groups containing multiple `AdapterError` instances.
* Cancellation.
* `KeyboardInterrupt`.
* `SystemExit`.
* Unrelated implementation failures.

This preserves useful failure information instead of selecting an arbitrary exception and potentially hiding a real cleanup defect.

## Tests and validation

The implementation includes focused coverage for:

* Modern and legacy SDK selection.
* Modern-first precedence.
* Absence of operational fallback.
* Transport dispatch.
* Mixed stdio and HTTP configurations.
* URL and header validation.
* HTTP client ownership.
* Redirect policy.
* Timeout propagation.
* Stream normalization.
* Initialization and tool discovery.
* Canonical trace parity.
* Cleanup after partial failures.
* Cancellation behavior.
* Secret redaction.
* Safe `ExceptionGroup` normalization.
* Existing stdio behavior and error wording.

Real SDK and integration validation included:

* MCP `1.12.4`.
* Latest stable MCP v1.
* Real modern Streamable HTTP loopback execution.
* Real legacy Streamable HTTP loopback execution.
* A real CLI invocation through `--mcp-host-target`.
* A real inaccessible endpoint to verify the public `AdapterError` boundary.
* Real stdio regression coverage.

Validation results:

* Full local suite: `526 passed, 1 skipped`
* Minimum MCP environment: `204 passed, 1 skipped`
* Latest-v1 environment: `204 passed, 1 skipped`
* Ordinary environment without MCP: `520 passed, 3 skipped`
* Ruff on changed files: passed
* mypy: passed with no issues
* `pip check`: passed in all isolated environments
* Workflow YAML parsing: passed
* `git diff --check`: passed

Local validation used Python 3.12 on Windows. GitHub Actions is configured to validate Python 3.11 on Ubuntu.

The latest-v1 matrix entry intentionally floats within `mcp>=1.12.4,<2`, so it can detect future stable MCP v1 releases that become incompatible while still satisfying the project’s declared dependency range.

## Documentation

This PR also:

* Documents the distinction between `--mcp-target` and `--mcp-host-target`.
* Adds valid stdio and Streamable HTTP runtime configuration examples.
* Documents transport-specific fields.
* Documents the no-redirect policy.
* Documents static header behavior and authentication limitations.
* Documents timeout and canonical trace behavior.
* Removes obsolete stdio-only wording.
* Updates the runner docstring to use transport-neutral terminology.
* Adds the new user-visible configuration surface under `[Unreleased]` in `CHANGELOG.md`.

## Out of scope

The PR intentionally does not include:

* OAuth
* Authorization discovery or token refresh
* Authenticated transport lifecycle
* Configured legacy SSE transport
* MCP resources
* MCP prompts
* Sampling
* Roots or default-deny roots
* Retries
* SSRF or endpoint allowlist policy
* MCP v2 behavior

Those remain follow-up work under the broader MCP host roadmap.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code or documentation?**

* [ ] No, I wrote all the code myself
* [x] Yes, I used AI assistance

**If you used AI assistance, briefly describe:**

* **Tool(s) used:** OpenAI Codex and ChatGPT.
* **Parts of the contribution that were AI-assisted:** Implementation planning, compatibility analysis, regression-test design, documentation and planning.
* **How I reviewed the output:** I reviewed the complete diff and verified each behavioral change against issue #161, the repository’s existing architecture, the supported MCP SDK range, and the contribution guidelines. I traced the implementation through the transport lifecycle, resource ownership, error boundaries, and canonical traces, and reviewed the final code to ensure the feature remained within scope.
* **Tests or checks I ran:** Full pytest suite, isolated MCP `1.12.4` and latest-v1 compatibility suites, ordinary no-MCP suite, real modern and legacy loopback simulations, real CLI execution, inaccessible-endpoint error replay, stdio regression tests, Ruff, mypy, `pip check`, documentation example validation, workflow YAML parsing, and `git diff --check`.

---

## Checklist before requesting a review

* [x] I have added a proper PR title and linked the issue
* [x] I have performed a self-review of my code
* [x] **I can explain the purpose of every documentation, function, class, and logic block I added**
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how the implementation handles them
* [x] If it is a core feature, I have added thorough tests
* [x] My code follows the project’s style guidelines and conventions
* [x] I added an entry under `[Unreleased]` in `CHANGELOG.md`
